### PR TITLE
Diagnostic fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(clr)
 cmake_minimum_required(VERSION 3.16.8)
+cmake_policy(VERSION 3.16...3.27)
+project(clr)
 
 ##########
 # Defaults

--- a/hipamd/hip-config-amd.cmake
+++ b/hipamd/hip-config-amd.cmake
@@ -95,7 +95,7 @@ set_target_properties(hip::amdhip64 PROPERTIES
 )
 
 get_target_property(amdhip64_type hip::amdhip64 TYPE)
-message(STATUS "hip::amdhip64 is ${amdhip64_type}")
+message(DEBUG "hip::amdhip64 is ${amdhip64_type}")
 
 if(NOT WIN32)
   set_target_properties(hip::device PROPERTIES
@@ -122,7 +122,7 @@ foreach(GPU_TARGET ${GPU_TARGETS})
     endif()
     hip_add_interface_link_flags(hip::device --offload-arch=${GPU_TARGET})
 endforeach()
-#Add support for parallel build and link
+# Add support for parallel build and link
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
   check_cxx_compiler_flag("-parallel-jobs=1" HIP_CLANG_SUPPORTS_PARALLEL_JOBS)
 endif()
@@ -133,7 +133,7 @@ if(HIP_CLANG_NUM_PARALLEL_JOBS GREATER 1)
     endif()
     hip_add_interface_link_flags(hip::device -parallel-jobs=${HIP_CLANG_NUM_PARALLEL_JOBS})
   else()
-    message("clang compiler doesn't support parallel jobs")
+    message(DEBUG "clang compiler doesn't support parallel jobs")
   endif()
 endif()
 
@@ -148,7 +148,7 @@ execute_process(
   RESULT_VARIABLE CLANGRT_BUILTINS_FETCH_EXIT_CODE)
 
 if( CLANGRT_Error )
-  message( STATUS "${HIP_CXX_COMPILER}: CLANGRT compiler options not supported.")
+  message(DEBUG "${HIP_CXX_COMPILER}: CLANGRT compiler options not supported.")
 else()
   # Add support for __fp16 and _Float16, explicitly link with compiler-rt
   if( "${CLANGRT_BUILTINS_FETCH_EXIT_CODE}" STREQUAL "0" )
@@ -156,6 +156,6 @@ else()
     set_property(TARGET hip::host APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${CLANGRT_BUILTINS}")
     set_property(TARGET hip::device APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${CLANGRT_BUILTINS}")
   else()
-    message(STATUS "clangrt builtins lib not found: ${CLANGRT_BUILTINS_FETCH_EXIT_CODE}")
+    message(DEBUG "clangrt builtins lib not found: ${CLANGRT_BUILTINS_FETCH_EXIT_CODE}")
   endif() # CLANGRT_BUILTINS_FETCH_EXIT_CODE Check
 endif() # CLANGRT_Error Check

--- a/hipamd/hip-config-amd.cmake
+++ b/hipamd/hip-config-amd.cmake
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 # Number of parallel jobs by default is 1
 if(NOT DEFINED HIP_CLANG_NUM_PARALLEL_JOBS)

--- a/rocclr/CMakeLists.txt
+++ b/rocclr/CMakeLists.txt
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 cmake_minimum_required(VERSION 3.5)
-
+cmake_policy(VERSION 3.5...3.27)
 project(ROCclr)
 
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})

--- a/rocclr/cmake/ROCclr.cmake
+++ b/rocclr/cmake/ROCclr.cmake
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 cmake_minimum_required(VERSION 3.5)
+cmake_policy(VERSION 3.5...3.27)
 
 # ROCclr abstracts the usage of multiple AMD compilers and runtimes.
 # It is possible to support multiple backends concurrently in the same binary.

--- a/rocclr/cmake/ROCclr.cmake
+++ b/rocclr/cmake/ROCclr.cmake
@@ -41,7 +41,9 @@ find_package(Threads REQUIRED)
 
 find_package(AMD_OPENCL)
 
-add_library(rocclr STATIC)
+if(NOT TARGET rocclr)
+  add_library(rocclr STATIC)
+endif()
 
 include(ROCclrCompilerOptions)
 


### PR DESCRIPTION
This PR implements two diagnostic-related changes:

- CMake 3.27 has deprecated script modes prioer to CMake 3.5 and issues a deprecation notice for all users running on latest CMake. While we do not use features that would necessitate bumping the minimum language reqs, Kitware has deprecated such old releases, so scripts currently being maintained should follow along.
- The configuration of [rocm-examples](https://github.com/amd/rocm-examples) is ridiculously noisy, because all samples are written in a self-sufficient (copy-paste friendly) manner, hence we `find_pakcage(HIP)` multiple times. As a result all uncached checks issuing a diagnostic are repeated on the console 30-ish times. These diagnostics have very little value to developers to be honest. The ones which are error path-related are defensible, but the library type diagnostic is almost like an AMD developer debug message that got committed somehow. No end-user cares about the library type of amdhip64.