### PR TITLE
Fix HIP assert in cooperative groups

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -46,17 +46,10 @@ THE SOFTWARE.
 #include <hip/amd_detail/hip_cooperative_groups_helper.h>
 #endif
 
-#define __hip_abort()                                                                              \
-  { asm("trap;"); }
 #if defined(NDEBUG)
 #define __hip_assert(COND)
 #else
-#define __hip_assert(COND)                                                                         \
-  {                                                                                                \
-    if (!COND) {                                                                                   \
-      __hip_abort();                                                                               \
-    }                                                                                              \
-  }
+#define __hip_assert(COND) assert();
 #endif
 
 namespace cooperative_groups {


### PR DESCRIPTION
The header was broken because `asm("trap;")` is a CUDA function and HIP does not support it.

The issue appeared only with the `-O0` flag because of the `NDEBUG` switch.

The recent HIP version supports device assert, therefore we are recommending its use in the recent bug fix.

If the mentioned solution is not preferred, we can replace `asm("trap;")` with `asm("s_trap 1;")` as a working alternative.

---

The MR solves https://github.com/ROCm-Developer-Tools/HIP/issues/233 and relates to  https://github.com/ROCm-Developer-Tools/HIP/issues/3317

Perhaps it relates to https://github.com/RadeonOpenCompute/ROCm/issues/1729