### PR TITLE
Fix cmake warnings with newer cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(clr)
 cmake_minimum_required(VERSION 3.16.8)
+project(clr)
 
 ##########
 # Defaults
@@ -42,7 +42,7 @@ endif()
 #############
 if(CLR_BUILD_HIP)
     if(NOT EXISTS ${HIPCC_BIN_DIR}/hipconfig)
-        message(FATAL_ERROR "Please pass hipcc/build or hipcc/bin using -DHIPCC_BIN_DIR. Passed HIPCC_BIN_DIR: "${HIPCC_BIN_DIR})
+        message(FATAL_ERROR "Please pass hipcc/build or hipcc/bin using -DHIPCC_BIN_DIR. Passed HIPCC_BIN_DIR: ${HIPCC_BIN_DIR}")
     endif()
     if(NOT DEFINED HIP_COMMON_DIR)
         message(FATAL_ERROR "Please pass HIP using -DHIP_COMMON_DIR. HIP_COMMON_DIR is incorrect")


### PR DESCRIPTION
When using newer cmake (3.27.5) to build the repository as described in the `How to install` section, the following cmake warnings are displayed:

```
CMake Warning (dev) at CMakeLists.txt:45:
  Syntax Warning in cmake code at column 113

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:21 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR fixes these issues.