### PR TITLE
FindHIP should be installed to ${CMAKE_ROOT}/Modules

### DIFF
--- a/hipamd/CMakeLists.txt
+++ b/hipamd/CMakeLists.txt
@@ -368,7 +368,7 @@ if(NOT ${INSTALL_SOURCE} EQUAL 0)
     if(WIN32)
       install(DIRECTORY ${HIP_COMMON_DIR}/cmake DESTINATION .)
     else()
-      install(DIRECTORY ${HIP_COMMON_DIR}/cmake/ DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
+      install(DIRECTORY ${HIP_COMMON_DIR}/cmake/ DESTINATION ${CMAKE_ROOT}/Modules)
     endif()
 endif()
 

--- a/hipamd/hip-backward-compat.cmake
+++ b/hipamd/hip-backward-compat.cmake
@@ -195,7 +195,7 @@ function(create_cmake_symlink)
     add_custom_target(link_${file_name} ALL
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                   COMMAND ${CMAKE_COMMAND} -E create_symlink
-                  ../../../${CMAKE_INSTALL_LIBDIR}/cmake/hip/FindHIP/${file_name} ${HIP_WRAPPER_FINDHIP_DIR}/FindHIP/${file_name})
+                  ${CMAKE_ROOT}/Modules/FindHIP/${file_name} ${HIP_WRAPPER_FINDHIP_DIR}/FindHIP/${file_name})
   endforeach()
   unset(config_files)
 

--- a/hipamd/packaging/CMakeLists.txt
+++ b/hipamd/packaging/CMakeLists.txt
@@ -106,7 +106,6 @@ install(FILES ${CMAKE_BINARY_DIR}/hipamd/share/hip/version DESTINATION ${CMAKE_I
 if(WIN32)
     install(FILES ${CMAKE_BINARY_DIR}/hipamd/share/hip/version DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME .hipVersion COMPONENT dev)
 endif()
-install(DIRECTORY ${HIP_COMMON_DIR}/cmake/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hip COMPONENT dev)
 install(FILES ${CMAKE_BINARY_DIR}/hipamd/hip-config.cmake ${CMAKE_BINARY_DIR}/hipamd/hip-config-version.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hip COMPONENT dev)
 install(FILES ${CMAKE_BINARY_DIR}/hipamd/hip-config-amd.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hip COMPONENT dev)
 install(FILES ${CMAKE_BINARY_DIR}/hipamd/hip-config-nvidia.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hip COMPONENT dev)


### PR DESCRIPTION
FindHIP.cmake is used in module mode in cmake, and modules should be placed in default location, ${CMAKE_ROOT}/Modules, so cmake can find it by default without appending CMAKE_MODULE_PATH. This is useful for distro installation.

Reference: https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
Reference: https://cmake.org/cmake/help/latest/variable/CMAKE_ROOT.html