### PR TITLE
LWPDCGSS-2256 - Improve library detection

### DIFF
--- a/hipamd/hip-config-amd.cmake
+++ b/hipamd/hip-config-amd.cmake
@@ -63,7 +63,7 @@ if(NOT HIP_CXX_COMPILER)
 endif()
 
 if(NOT WIN32)
-  find_dependency(AMDDeviceLibs)
+  find_dependency(AMDDeviceLibs HINTS ${ROCM_PATH})
 endif()
 
 # If AMDGPU_TARGETS is not defined by the app, amdgpu-arch is run to find the gpu archs
@@ -96,7 +96,7 @@ endif()
 set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU targets to compile for")
 
 if(NOT WIN32)
-  find_dependency(amd_comgr)
+  find_dependency(amd_comgr HINTS ${ROCM_PATH})
 endif()
 
 include( "${CMAKE_CURRENT_LIST_DIR}/hip-targets.cmake" )
@@ -105,7 +105,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/hip-targets.cmake" )
 #This makes the cmake generated file xxxx-targets to supply the linker libraries
 # without worrying other transitive dependencies
 if(NOT WIN32)
-  find_dependency(hsa-runtime64)
+  find_dependency(hsa-runtime64 HINTS ${ROCM_PATH})
   find_dependency(Threads)
 endif()
 


### PR DESCRIPTION
Add HINTS to find_dependency calls to ensure find_package(HIP) works without having to set ROCM_PATH or CMAKE_PREFIX_PATH externally.

With this change, having find_package(HIP CONFIG PATHS $ENV{ROCM_PATH} "/opt/rocm") will properly detect the additional libaries. Without it, CMAKE_PREFIX_PATH has to be set to /opt/rocm to be able to configure