### PR TITLE
Revert "SWDEV-301667 - Increase default signal pool to 4096"

### DIFF
--- a/rocclr/utils/flags.hpp
+++ b/rocclr/utils/flags.hpp
@@ -219,7 +219,7 @@ release(uint, ROC_P2P_SDMA_SIZE, 1024,                                        \
         "The minimum size in KB for P2P transfer with SDMA")                  \
 release(uint, ROC_AQL_QUEUE_SIZE, 16384,                                      \
         "AQL queue size in AQL packets")                                      \
-release(uint, ROC_SIGNAL_POOL_SIZE, 4096,                                     \
+release(uint, ROC_SIGNAL_POOL_SIZE, 32,                                       \
         "Initial size of HSA signal pool")                                    \
 release(uint, DEBUG_CLR_LIMIT_BLIT_WG, 16,                                    \
         "Limit the number of workgroups in blit operations")                  \


### PR DESCRIPTION
This reverts commit 94c7004df87cce4b6b0902b365a96905140312f0.

The reason for revert is: the original change introduces a bug in OpenCL when more than one command queue is created:
https://github.com/ROCm/ROCR-Runtime/issues/186

Also, in the orignal commit no reason for the change is provided.

In addition to that, 4096 is a particularly bad value (too large) as by default the kernel can only provide 4094 events for DGPUs.