### PR TITLE
Add flag ROC_SIGNAL_POOL_SIZE_PROFILE and update default value

### DIFF
--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -355,10 +355,9 @@ VirtualGPU::HwQueueTracker::~HwQueueTracker() {
 
 // ================================================================================================
 bool VirtualGPU::HwQueueTracker::Create() {
-  uint kSignalListSize = ROC_SIGNAL_POOL_SIZE;
-  if (activity_prof::IsEnabled(OP_ID_DISPATCH) || gpu_.profiling_) {
-    kSignalListSize = !flagIsDefault(ROC_SIGNAL_POOL_SIZE) ? ROC_SIGNAL_POOL_SIZE : 4 * Ki;
-  }
+  bool isProfile = activity_prof::IsEnabled(OP_ID_DISPATCH) || gpu_.profiling_;
+  uint kSignalListSize = isProfile ? ROC_SIGNAL_POOL_SIZE_PROFILE : ROC_SIGNAL_POOL_SIZE;
+
   signal_list_.resize(kSignalListSize);
 
   hsa_agent_t agent = gpu_.gpu_device();

--- a/rocclr/utils/flags.hpp
+++ b/rocclr/utils/flags.hpp
@@ -221,6 +221,8 @@ release(uint, ROC_AQL_QUEUE_SIZE, 16384,                                      \
         "AQL queue size in AQL packets")                                      \
 release(uint, ROC_SIGNAL_POOL_SIZE, 4096,                                     \
         "Initial size of HSA signal pool")                                    \
+release(uint, ROC_SIGNAL_POOL_SIZE_PROFILE, 1000,                             \
+        "Initial size of HSA signal pool")                                    \
 release(uint, DEBUG_CLR_LIMIT_BLIT_WG, 16,                                    \
         "Limit the number of workgroups in blit operations")                  \
 release(bool, ROC_SKIP_KERNEL_ARG_COPY, false,                                \


### PR DESCRIPTION
The change is two-fold:

- add a flag to configure the pool size used when profiling, this allows to clearly configure the two values (profile vs. not-profile).

- change the size of the profile pool down from 4096 which was too large: the kernel only provides 4094 events for DGPUs, *and* using two command-queues in OpenCL results in the bug described here:
https://github.com/ROCm/ROCR-Runtime/issues/186

The new default of 1000 has this rationale: it allows up to 4 queues to fit within the 4094 events provided by the kernel (with a little margin).