### PR TITLE
Support compressed device binaries

### DIFF
--- a/hipamd/src/hip_code_object.cpp
+++ b/hipamd/src/hip_code_object.cpp
@@ -36,6 +36,7 @@ hipError_t ihipFree(void* ptr);
 hipError_t ihipMallocManaged(void** ptr, size_t size, unsigned int align = 0);
 namespace {
 constexpr char kOffloadBundleMagicStr[] = "__CLANG_OFFLOAD_BUNDLE__";
+constexpr char kOffloadCompressedBundleMagicStr[] = "CCOB";
 constexpr char kOffloadKindHip[] = "hip";
 constexpr char kOffloadKindHipv4[] = "hipv4";
 constexpr char kOffloadKindHcc[] = "hcc";
@@ -43,6 +44,9 @@ constexpr char kAmdgcnTargetTriple[] = "amdgcn-amd-amdhsa-";
 
 // ClangOFFLOADBundle info.
 static constexpr size_t kOffloadBundleMagicStrSize = sizeof(kOffloadBundleMagicStr);
+
+// Compressed ClangOFFLOADBundle info.
+static constexpr size_t kOffloadCompressedBundleMagicStrSize = sizeof(kOffloadCompressedBundleMagicStr);
 
 // Clang Offload bundler description & Header.
 struct __ClangOffloadBundleInfo {
@@ -62,6 +66,11 @@ struct __ClangOffloadBundleHeader {
 bool CodeObject::IsClangOffloadMagicBundle(const void* data) {
   std::string magic(reinterpret_cast<const char*>(data), kOffloadBundleMagicStrSize - 1);
   return magic.compare(kOffloadBundleMagicStr) ? false : true;
+}
+
+bool CodeObject::IsClangOffloadMagicCompressedBundle(const void* data) {
+  std::string magic(reinterpret_cast<const char*>(data), kOffloadCompressedBundleMagicStrSize - 1);
+  return magic.compare(kOffloadCompressedBundleMagicStr) ? false : true;
 }
 
 uint64_t CodeObject::ElfSize(const void* emi) { return amd::Elf::getElfSize(emi); }

--- a/hipamd/src/hip_code_object.hpp
+++ b/hipamd/src/hip_code_object.hpp
@@ -64,6 +64,7 @@ class CodeObject {
   static uint64_t ElfSize(const void* emi);
 
   static bool IsClangOffloadMagicBundle(const void* data);
+  static bool IsClangOffloadMagicCompressedBundle(const void* data);
 
 protected:
   //Given an ptr to image or file, extracts to code object


### PR DESCRIPTION
Depends on ROCm/llvm-project#65.

This enables support for loading compressed device binaries (generated with `--offload-compress` flag) implemented in https://github.com/llvm/llvm-project/commit/7e2823438e920d25364ff92b62ad90020c31bb59. For more details on the motivation, please see ROCm/llvm-project#65.
