### PR TITLE
Fix compilation errors with musl libc

### DIFF
--- a/rocclr/os/os.hpp
+++ b/rocclr/os/os.hpp
@@ -29,6 +29,7 @@
 
 #if defined(__linux__)
 #include <sched.h>
+#include <libgen.h>
 #endif
 
 #ifdef _WIN32
@@ -373,6 +374,10 @@ ALWAYSINLINE address Os::currentStackPtr() {
 
 
 #if defined(__linux__)
+
+#ifndef __GLIBC__
+typedef unsigned long int __cpu_mask;
+#endif
 
 inline void Os::ThreadAffinityMask::init() { CPU_ZERO(&mask_); }
 


### PR DESCRIPTION
1. According to POSIX specification, basename(3) belongs to `libgen.h`[1]
2. `__cpu_mask` is an internal type of glibc's cpu_set implementation, not part of the POSIX specification, so musl does not support it too.

[1] https://man7.org/linux/man-pages/man3/basename.3.html