### PR TITLE
Revert "SWDEV-365820 - Refactor build path"

### DIFF
--- a/rocclr/device/devprogram.cpp
+++ b/rocclr/device/devprogram.cpp
@@ -668,7 +668,7 @@ bool Program::compileImplLC(const std::string& sourceCode,
     driverOptions.push_back("-mwavefrontsize64");
   }
   driverOptions.push_back("-mcode-object-version=" + std::to_string(options->oVariables->LCCodeObjectVersion));
-
+ 
   // Iterate through each source code and dump it into tmp
   std::fstream f;
   std::vector<std::string> headerFileNames(headers.size());
@@ -1425,6 +1425,13 @@ bool Program::initBuild(amd::option::Options* options) {
     DevLogError("Init CL Binary failed \n");
     return false;
   }
+
+  std::string targetID = device().isa().targetId();
+#if defined(_WIN32)
+  // Replace special charaters that are not supported by Windows FS.
+  std::replace(targetID.begin(), targetID.end(), ':', '@');
+#endif
+  options->setPerBuildInfo(targetID.c_str(), clBinary()->getEncryptCode(), true);
 
   // Elf Binary setup
   std::string outFileName;


### PR DESCRIPTION
This reverts commit 3f2f7252aac5b9524162027b0237c6c6695f5347.

Reason: it breaks -save-temps in OpenCL

See bug report: https://github.com/ROCm/ROCm/issues/2940