### PR TITLE
Fix gfx8 opencl

### DIFF
--- a/rocclr/device/device.hpp
+++ b/rocclr/device/device.hpp
@@ -1431,9 +1431,6 @@ class Isa {
 
   /// @returns If the ROCm runtime supports the ISA.
   bool runtimeRocSupported() const {
-    if (!IS_HIP && (versionMajor_ == 8)) {
-      return false;
-    }
     return runtimeRocSupported_;
   }
 


### PR DESCRIPTION
This condition was added when we supported PAL openCL on gfx8, but when ROC_ENABLE_PRE_VEGA was dropped and PAL OpenCL on Linux was deprecated, this logic should have been dropped completely.