### PR TITLE
Print dlopen error on stderr

### DIFF
--- a/opencl/khronos/icd/loader/linux/icd_linux.c
+++ b/opencl/khronos/icd/loader/linux/icd_linux.c
@@ -175,7 +175,7 @@ void *khrIcdOsLibraryLoad(const char *libraryName)
     void *retVal = dlopen (libraryName, RTLD_NOW);
 
     if (NULL == retVal) {
-        printf("dlerror: %s\n", dlerror());
+        fprintf(stderr, "dlerror: %s\n", dlerror());
     }
 
     return retVal;


### PR DESCRIPTION
Otherwise a package that happens to try to load opencl to get information (e.g. hwloc-calc) would spuriously emit output that disturbs further processing, e.g.:

$ N=$(hwloc-calc all -N node)
$ echo "$N"
dlerror: libamd_comgr.so.2: cannot open shared object file: No such file or directory 2