### PR TITLE
SWDEV-506793 - segfault in ihipMallocManaged when no devices are available

### DIFF
--- a/hipamd/src/hip_hmm.cpp
+++ b/hipamd/src/hip_hmm.cpp
@@ -287,6 +287,10 @@ hipError_t ihipMallocManaged(void** ptr, size_t size, unsigned int align) {
   assert((hip::host_context != nullptr) && "Current host context must be valid");
   amd::Context& ctx = *hip::host_context;
 
+  if (ctx.devices().size() == 0) {
+    return hipErrorNoDevice;
+  }
+
   const amd::Device& dev = *ctx.devices()[0];
 
   // Allocate SVM fine grain buffer with the forced host pointer, avoiding explicit memory

--- a/hipamd/src/hip_hmm.cpp
+++ b/hipamd/src/hip_hmm.cpp
@@ -287,10 +287,6 @@ hipError_t ihipMallocManaged(void** ptr, size_t size, unsigned int align) {
   assert((hip::host_context != nullptr) && "Current host context must be valid");
   amd::Context& ctx = *hip::host_context;
 
-  if (ctx.devices().size() == 0) {
-    return hipErrorNoDevice;
-  }
-
   const amd::Device& dev = *ctx.devices()[0];
 
   // Allocate SVM fine grain buffer with the forced host pointer, avoiding explicit memory

--- a/hipamd/src/hip_platform.cpp
+++ b/hipamd/src/hip_platform.cpp
@@ -153,25 +153,28 @@ void __hipRegisterManagedVar(
     const char* name,  // Name of the variable in code object
     size_t size, unsigned align) {
   HIP_INIT_VOID();
-  hipError_t status = ihipMallocManaged(pointer, size, align);
-  if (status == hipSuccess) {
-    hip::Stream* stream = hip::getNullStream();
-    if (stream != nullptr) {
-      status = ihipMemcpy(*pointer, init_value, size, hipMemcpyHostToDevice, *stream);
-      guarantee((status == hipSuccess), "Error during memcpy to managed memory, error:%d!",
-                                         status);
+
+  if (hip::g_devices.size() > 0) {
+    hipError_t status = ihipMallocManaged(pointer, size, align);
+    if (status == hipSuccess) {
+      hip::Stream* stream = hip::getNullStream();
+      if (stream != nullptr) {
+        status = ihipMemcpy(*pointer, init_value, size, hipMemcpyHostToDevice, *stream);
+        guarantee((status == hipSuccess), "Error during memcpy to managed memory, error:%d!",
+                                           status);
+      } else {
+        ClPrint(amd::LOG_ERROR, amd::LOG_API, "Host Queue is NULL");
+      }
     } else {
-      ClPrint(amd::LOG_ERROR, amd::LOG_API, "Host Queue is NULL");
+      guarantee(false, "Error during allocation of managed memory!, error: %d", status);
     }
-  } else if (status == hipErrorNoDevice) {
+  } else {
     *pointer = nullptr;
     size = 0;
-  } else {
-    guarantee(false, "Error during allocation of managed memory!, error: %d", status);
   }
   hip::Var* var_ptr = new hip::Var(std::string(name), hip::Var::DeviceVarKind::DVK_Managed, pointer,
                                    size, align, reinterpret_cast<hip::FatBinaryInfo**>(hipModule));
-  status = PlatformState::instance().registerStatManagedVar(var_ptr);
+  hipError_t status = PlatformState::instance().registerStatManagedVar(var_ptr);
   guarantee((status == hipSuccess), "Cannot register Static Managed Var, error: %d", status);
 }
 

--- a/hipamd/src/hip_platform.cpp
+++ b/hipamd/src/hip_platform.cpp
@@ -163,6 +163,9 @@ void __hipRegisterManagedVar(
     } else {
       ClPrint(amd::LOG_ERROR, amd::LOG_API, "Host Queue is NULL");
     }
+  } else if (status == hipErrorNoDevice) {
+    *pointer = nullptr;
+    size = 0;
   } else {
     guarantee(false, "Error during allocation of managed memory!, error: %d", status);
   }


### PR DESCRIPTION
A segfault was occurring immediately in HIP programs that uses static managed memory (i.e. globals with `__managed__` modifier).

This avoids a segfault in `ihipMallocManaged()` when no devices are available. And because this happens during initialization before entering `main()`, we do not abort. Instead, the managed pointer is set to nullptr.