### PR TITLE
SWDEV-341212 - HIP header changes for supporting SPIR-V

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_warp_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_functions.h
@@ -123,8 +123,8 @@ unsigned long long __activemask() {
 #endif // HIP_ENABLE_WARP_SYNC_BUILTINS
 
 __device__ static inline unsigned int __lane_id() {
-    return  __builtin_amdgcn_mbcnt_hi(
-        -1, __builtin_amdgcn_mbcnt_lo(-1, 0));
+    if (warpSize == 32) return __builtin_amdgcn_mbcnt_lo(-1, 0);
+    return __builtin_amdgcn_mbcnt_hi(-1, __builtin_amdgcn_mbcnt_lo(-1, 0));
 }
 
 __device__


### PR DESCRIPTION
This fell through the cracks of #111, and is necessary for the initial release having SPIR-V support. It is a NOP on concrete targets.