### PR TITLE
Implement currentStackPtr for PowerPC64

### DIFF
--- a/rocclr/include/top.hpp
+++ b/rocclr/include/top.hpp
@@ -25,6 +25,8 @@
 #define ATI_ARCH_ARM
 #elif defined(i386) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(__x86__) || defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
 #define ATI_ARCH_X86
+#elif defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
+#define ATI_ARCH_PPC64
 #endif
 
 #if defined(ATI_ARCH_ARM)

--- a/rocclr/os/os.hpp
+++ b/rocclr/os/os.hpp
@@ -358,6 +358,9 @@ ALWAYSINLINE address Os::currentStackPtr() {
 #elif defined(ATI_ARCH_ARM)
       "mov %0,sp"
       : "=r"(value)
+#elif defined(ATI_ARCH_PPC64)
+      "mr r1,%0"
+      : "=r"(value)
 #else
       ""
 #endif


### PR DESCRIPTION
## Issue

Related to https://github.com/ROCm/clr/issues/61

## Changes

* Introduce PowerPC64 implementation for `Os::currentStackPtr`

## Notes

This implementation should work with both Big and Little Endian