### PR TITLE
Update targets for hip-config-nvidia

### DIFF
--- a/hipamd/CMakeLists.txt
+++ b/hipamd/CMakeLists.txt
@@ -446,7 +446,7 @@ configure_package_config_file(
       )
 
 configure_package_config_file(
-      hip-config-nvidia.cmake
+      hip-config-nvidia.cmake.in
       ${CMAKE_CURRENT_BINARY_DIR}/hip-config-nvidia.cmake
       INSTALL_DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR}
       PATH_VARS LIB_INSTALL_DIR INCLUDE_INSTALL_DIR BIN_INSTALL_DIR

--- a/hipamd/hip-config-nvidia.cmake.in
+++ b/hipamd/hip-config-nvidia.cmake.in
@@ -18,6 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_library(hip::device INTERFACE IMPORTED)
-add_library(hip::host INTERFACE IMPORTED)
-add_library(hip::amdhip64 INTERFACE IMPORTED)
+foreach(__lib device host amdhip64)
+    if (NOT TARGET hip::${__lib})
+        add_library(hip::${__lib} INTERFACE IMPORTED)
+        set_target_properties(hip::${__lib} PROPERTIES
+		INTERFACE_COMPILE_DEFINITIONS "__HIP_PLATFORM_NVIDIA__=1"
+		INTERFACE_INCLUDE_DIRECTORIES @PACKAGE_INCLUDE_INSTALL_DIR@
+		INTERFACE_SYSTEM_INCLUDE_DIRECTORIES @PACKAGE_INCLUDE_INSTALL_DIR@)
+    endif()
+endforeach()


### PR DESCRIPTION
This change aims to fix issues when using cmake with hip::device, hip::host, or hip::amdhip64 on Nvidia. Fixes https://github.com/ROCm/hip/issues/3748, and is a minor edit of https://github.com/ROCm/clr/pull/125/files.