### PR TITLE
fix: GraphNode CreateCommand check command status

### DIFF
--- a/hipamd/src/hip_graph_internal.hpp
+++ b/hipamd/src/hip_graph_internal.hpp
@@ -1193,6 +1193,9 @@ class GraphKernelNode : public GraphNode {
     status = ihipLaunchKernelCommand(
         command, func, launch_params, stream, kernelParams_.kernelParams, kernelParams_.extra,
         kernelEvents_.startEvent_, kernelEvents_.stopEvent_, flags, coopKernel_, 0, 0, 0, 0, 0);
+    if (status != hipSuccess) {
+      return status;
+    }
     if (signal_is_required_) {
       // Optimize the barriers by adding a signal into the dispatch packet directly
       command->SetProfiling();
@@ -1390,7 +1393,10 @@ class GraphMemcpyNode : public GraphNode {
     commands_.reserve(1);
     amd::Command* command;
     status = ihipMemcpy3DCommand(command, &copyParams_, stream);
-    commands_.emplace_back(command);
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
+    }
+    
     return status;
   }
 
@@ -1568,6 +1574,10 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
       WorkerThreadLock_.lock();
     }
     status = ihipMemcpyCommand(command, dst_, src_, count_, kind_, *stream);
+    if (status != hipSuccess) {
+      return status;
+    }
+
     hip::MemcpyType type = ihipGetMemcpyType(src_, dst_, kind_);
     if (type == hipCopyBuffer) {
       amd::CopyMemoryCommand* cpycmd = reinterpret_cast<amd::CopyMemoryCommand*>(command);
@@ -1767,10 +1777,10 @@ class GraphMemcpyNodeFromSymbol : public GraphMemcpyNode1D {
       return status;
     }
     status = ihipMemcpyCommand(command, dst_, device_ptr, count_, kind_, *stream);
-    if (status != hipSuccess) {
-      return status;
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
     }
-    commands_.emplace_back(command);
+
     return status;
   }
 
@@ -1862,10 +1872,10 @@ class GraphMemcpyNodeToSymbol : public GraphMemcpyNode1D {
       return status;
     }
     status = ihipMemcpyCommand(command, device_ptr, src_, count_, kind_, *stream);
-    if (status != hipSuccess) {
-      return status;
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
     }
-    commands_.emplace_back(command);
+
     return status;
   }
 
@@ -2118,7 +2128,10 @@ class GraphEventRecordNode : public GraphNode {
     commands_.reserve(1);
     amd::Command* command = nullptr;
     status = e->recordCommand(command, stream);
-    commands_.emplace_back(command);
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
+    }
+
     return status;
   }
 
@@ -2174,7 +2187,10 @@ class GraphEventWaitNode : public GraphNode {
     commands_.reserve(1);
     amd::Command* command;
     status = e->streamWaitCommand(command, stream);
-    commands_.emplace_back(command);
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
+    }
+
     return status;
   }
 
@@ -2223,6 +2239,9 @@ class GraphHostNode : public GraphNode {
     amd::Command::EventWaitList waitList;
     commands_.reserve(1);
     amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
+    if (command == nullptr) {
+      return hipErrorOutOfMemory;
+    }
     commands_.emplace_back(command);
     return hipSuccess;
   }
@@ -2284,6 +2303,9 @@ class GraphEmptyNode : public GraphNode {
       amd::Command::EventWaitList waitList;
       commands_.reserve(1);
       amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
+      if (command == nullptr) {
+        return hipErrorOutOfMemory;
+      }
       commands_.emplace_back(command);
     }
     return hipSuccess;
@@ -2565,7 +2587,10 @@ class GraphDrvMemcpyNode : public GraphNode {
     commands_.reserve(1);
     amd::Command* command;
     status = ihipGetMemcpyParam3DCommand(command, &copyParams_, stream);
-    commands_.emplace_back(command);
+    if (status == hipSuccess) {
+      commands_.emplace_back(command);
+    }
+
     return status;
   }
 

--- a/hipamd/src/hip_graph_internal.hpp
+++ b/hipamd/src/hip_graph_internal.hpp
@@ -2238,11 +2238,14 @@ class GraphHostNode : public GraphNode {
     }
     amd::Command::EventWaitList waitList;
     commands_.reserve(1);
-    amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-    if (command == nullptr) {
+    try {
+      amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
+      commands_.emplace_back(command);
+    } catch (const std::bad_alloc&) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] Failed to new amd::Marker in GraphHostNode!\n");
       return hipErrorOutOfMemory;
     }
-    commands_.emplace_back(command);
     return hipSuccess;
   }
 
@@ -2260,14 +2263,15 @@ class GraphHostNode : public GraphNode {
       // Add the new barrier to stall the stream, until the callback is done
       amd::Command::EventWaitList eventWaitList;
       eventWaitList.push_back(commands_[0]);
-      amd::Command* block_command =
-          new amd::Marker(*commands_[0]->queue(), !kMarkerDisableFlush, eventWaitList);
-      if (block_command == nullptr) {
+      try {
+        amd::Command* block_command =
+            new amd::Marker(*commands_[0]->queue(), !kMarkerDisableFlush, eventWaitList);
+        block_command->enqueue();
+        block_command->release();
+        commands_[0]->release();
+      } catch (const std::bad_alloc&) {
         ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed during block command creation");
       }
-      block_command->enqueue();
-      block_command->release();
-      commands_[0]->release();
     }
   }
 
@@ -2302,11 +2306,14 @@ class GraphEmptyNode : public GraphNode {
     if (DEBUG_HIP_FORCE_GRAPH_QUEUES != 1) {
       amd::Command::EventWaitList waitList;
       commands_.reserve(1);
-      amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-      if (command == nullptr) {
+      try {
+        amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
+        commands_.emplace_back(command);
+      } catch (const std::bad_alloc&) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph] Failed to new amd::Marker in GraphEmptyNode!\n");
         return hipErrorOutOfMemory;
       }
-      commands_.emplace_back(command);
     }
     return hipSuccess;
   }
@@ -2664,14 +2671,17 @@ class hipGraphExternalSemSignalNode : public GraphNode {
     commands_.reserve(numExtSems);
     for (unsigned int i = 0; i < numExtSems; i++) {
       if (externalSemaphorNodeParam_.extSemArray[i] != nullptr) {
-        amd::ExternalSemaphoreCmd* command = new amd::ExternalSemaphoreCmd(*stream,
-                                      externalSemaphorNodeParam_.extSemArray[i],
-                                      externalSemaphorNodeParam_.paramsArray[i].params.fence.value,
-                                      amd::ExternalSemaphoreCmd::COMMAND_SIGNAL_EXTSEMAPHORE);
-        if (command == nullptr) {
+        try {
+          amd::ExternalSemaphoreCmd* command = new amd::ExternalSemaphoreCmd(*stream,
+                                        externalSemaphorNodeParam_.extSemArray[i],
+                                        externalSemaphorNodeParam_.paramsArray[i].params.fence.value,
+                                        amd::ExternalSemaphoreCmd::COMMAND_SIGNAL_EXTSEMAPHORE);
+          commands_.emplace_back(command);
+        } catch (const std::bad_alloc&) {
+          ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                  "[hipGraph] Failed to new amd::ExternalSemaphoreCmd in hipGraphExternalSemSignalNode!\n");
           return hipErrorOutOfMemory;
         }
-        commands_.emplace_back(command);
       } else {
         return hipErrorInvalidValue;
       }
@@ -2718,14 +2728,17 @@ class hipGraphExternalSemWaitNode : public GraphNode {
     commands_.reserve(numExtSems);
     for (unsigned int i = 0; i < numExtSems; i++) {
       if (externalSemaphorNodeParam_.extSemArray[i] != nullptr) {
-        amd::ExternalSemaphoreCmd* command = new amd::ExternalSemaphoreCmd(*stream,
-                                    externalSemaphorNodeParam_.extSemArray[i],
-                                    externalSemaphorNodeParam_.paramsArray[i].params.fence.value,
-                                    amd::ExternalSemaphoreCmd::COMMAND_WAIT_EXTSEMAPHORE);
-        if (command == nullptr) {
+        try {
+          amd::ExternalSemaphoreCmd* command = new amd::ExternalSemaphoreCmd(*stream,
+                                      externalSemaphorNodeParam_.extSemArray[i],
+                                      externalSemaphorNodeParam_.paramsArray[i].params.fence.value,
+                                      amd::ExternalSemaphoreCmd::COMMAND_WAIT_EXTSEMAPHORE);
+          commands_.emplace_back(command);
+        } catch (const std::bad_alloc&) {
+          ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                  "[hipGraph] Failed to new amd::ExternalSemaphoreCmd in hipGraphExternalSemWaitNode!\n");
           return hipErrorOutOfMemory;
         }
-        commands_.emplace_back(command);
       } else {
         return hipErrorInvalidValue;
       }
@@ -2767,14 +2780,20 @@ class hipGraphBatchMemOpNode : public GraphNode {
       return status;
     }
     amd::Command::EventWaitList waitList;
-    amd::BatchMemoryOperationCommand* command = new amd::BatchMemoryOperationCommand(
-        *stream, ROCCLR_COMMAND_BATCH_STREAM, batchMemOpNodeParam_.count,
-        batchMemOpNodeParam_.flags, waitList, batchMemOpNodeParam_.paramArray,
-        sizeof(hipStreamBatchMemOpParams));
-    if (command == nullptr) {
+    try {
+      amd::BatchMemoryOperationCommand* command = new amd::BatchMemoryOperationCommand(
+          *stream, ROCCLR_COMMAND_BATCH_STREAM, batchMemOpNodeParam_.count,
+          batchMemOpNodeParam_.flags, waitList, batchMemOpNodeParam_.paramArray,
+          sizeof(hipStreamBatchMemOpParams));
+      if (command == nullptr) {
+        return hipErrorOutOfMemory;
+      }
+      commands_.emplace_back(command);
+    } catch (const std::bad_alloc&) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] Failed to new amd::BatchMemoryOperationCommand in hipGraphBatchMemOpNode!\n");
       return hipErrorOutOfMemory;
     }
-    commands_.emplace_back(command);
     return hipSuccess;
   }
 


### PR DESCRIPTION
Creating commands in GraphNode.CreateCommand() fails when the system is out of memory, but still adds a null pointer to **commands_**, causing a crash when traversing and using **commands_**.

The crash occurs at: 
https://github.com/ROCm/clr/blob/amd-staging/hipamd/src/hip_graph_internal.hpp#L381