### PR TITLE
Fix MSVC usage of __has_attribute in amd_hip_vector_types.h

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
@@ -36,8 +36,8 @@ THE SOFTWARE.
     #define __HOST_DEVICE__ __host__ __device__
 #endif
 
-// __has_attribute is defined as 0 by LLVM headers when compiling from MSVC. Use "#if" instead of "#if defined()" to support MSVC.
-#if __has_attribute
+// __has_attribute is defined as 0 by LLVM headers when compiling from MSVC. Fix to support MSVC.
+#if defined(__has_attribute) && (!defined(_MSC_VER) || defined(__HIPCC__))
     #if __has_attribute(ext_vector_type)
         #define __HIP_USE_NATIVE_VECTOR__ 1
         #define __NATIVE_VECTOR__(n, T) T __attribute__((ext_vector_type(n)))

--- a/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
@@ -36,7 +36,8 @@ THE SOFTWARE.
     #define __HOST_DEVICE__ __host__ __device__
 #endif
 
-#if defined(__has_attribute)
+// __has_attribute is defined as 0 by LLVM headers when compiling from MSVC. Use #if instead of #ifdef to support MSVC.
+#if __has_attribute
     #if __has_attribute(ext_vector_type)
         #define __HIP_USE_NATIVE_VECTOR__ 1
         #define __NATIVE_VECTOR__(n, T) T __attribute__((ext_vector_type(n)))

--- a/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
@@ -36,7 +36,7 @@ THE SOFTWARE.
     #define __HOST_DEVICE__ __host__ __device__
 #endif
 
-// __has_attribute is defined as 0 by LLVM headers when compiling from MSVC. Use #if instead of #ifdef to support MSVC.
+// __has_attribute is defined as 0 by LLVM headers when compiling from MSVC. Use "#if" instead of "#if defined()" to support MSVC.
 #if __has_attribute
     #if __has_attribute(ext_vector_type)
         #define __HIP_USE_NATIVE_VECTOR__ 1


### PR DESCRIPTION
`__has_attribute` is defined as 0 by LLVM headers when compiling from MSVC.

Context: https://github.com/ROCm/TheRock/discussions/409#discussioncomment-13019261 and https://github.com/ROCm/TheRock/discussions/409#discussioncomment-13019326