### PR TITLE
[windows] Use is_versioned = true consistently in both Comgr::LoadLib paths.

### DIFF
--- a/rocclr/device/device.cpp
+++ b/rocclr/device/device.cpp
@@ -683,7 +683,7 @@ bool Device::ValidateComgr() {
 #if defined(USE_COMGR_LIBRARY)
   // Check if Lightning compiler was requested
   if (settings_->useLightning_) {
-    constexpr bool kComgrVersioned = false;
+    constexpr bool kComgrVersioned = true;
     std::call_once(amd::Comgr::initialized, amd::Comgr::LoadLib, kComgrVersioned);
     // Use Lightning only if it's available
     settings_->useLightning_ = amd::Comgr::IsReady();


### PR DESCRIPTION
Prior to this, RTCProgram was using is_version = true and device initialization was using false. On Windows, this was causing us to attempt to load amd_comgr_3.dll at device load and amd_comgr0605.dll for RTC programs. Obviously, there is only one DLL and it must be used consistently.