### PR TITLE
NULL check `environ` before dereference

### DIFF
--- a/rocclr/utils/flags.cpp
+++ b/rocclr/utils/flags.cpp
@@ -119,11 +119,11 @@ bool Flag::init() {
 #else  // !_WIN32
 #ifdef __APPLE__
   char** environ = *_NSGetEnviron();
+#endif  // __APPLE__
+
   if (environ == NULL) {
     return false;
   }
-#endif  // __APPLE__
-
   for (const char** p = const_cast<const char**>(environ); *p != NULL; ++p) {
     std::string var = *p;
     size_t pos = var.find('=');


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Closes https://github.com/ROCm/clr/issues/164

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

NULL check `environ` before dereference.

## Why are these changes needed?

To prevent dereferencing NULL pointer.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
