### PR TITLE
SWDEV-540609 - hipGraph capture of hipExtModuleLaunchKernel assumed grid size was a multiple of block size

### DIFF
--- a/hipamd/src/hip_graph.cpp
+++ b/hipamd/src/hip_graph.cpp
@@ -276,8 +276,7 @@ hipError_t ihipExtLaunchKernel(hipStream_t stream, hipFunction_t f, uint32_t glo
   nodeParams.func = f;
   nodeParams.blockDim = dim3(localWorkSizeX, localWorkSizeY, localWorkSizeZ);
   nodeParams.extra = extra;
-  nodeParams.gridDim = dim3(globalWorkSizeX / localWorkSizeX, globalWorkSizeY / localWorkSizeY,
-                            globalWorkSizeZ / localWorkSizeZ);
+  nodeParams.gridDim = dim3(globalWorkSizeX, globalWorkSizeY, globalWorkSizeZ);
   nodeParams.kernelParams = kernelParams;
   nodeParams.sharedMemBytes = sharedMemBytes;
 
@@ -314,7 +313,7 @@ hipError_t capturehipExtLaunchKernel(hipStream_t& stream, const void*& hostFunct
           "[hipGraph] Current capture node ExtLaunchKernel on stream : %p", stream);
   return ihipExtLaunchKernel(
       stream, reinterpret_cast<hipFunction_t>(const_cast<void*>(hostFunction)),
-      gridDim.x * blockDim.x, gridDim.y * blockDim.y, gridDim.z * blockDim.z, blockDim.x,
+      gridDim.x, gridDim.y, gridDim.z, blockDim.x,
       blockDim.y, blockDim.z, sharedMemBytes, args, nullptr, startEvent, stopEvent, flags);
 }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Fixes SWDEV-540609.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

hipGraph capture of hipExtModuleLaunchKernel assumed grid size was a multiple of block size.

## Why are these changes needed?

Certain MIOpen solutions perform transpose + GEMM + transpose and the grid dims are incorrectly captured resulting in incorrect results.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
