### PR TITLE
SWDEV-542264 - Instead of manually unrolling the memcpy/memset use the built-in versions and let the compiler decide

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -959,65 +959,13 @@ unsigned __smid(void)
 
 #endif //defined(__clang__) && defined(__HIP__)
 
-
-// loop unrolling
-static inline __device__ void* __hip_hc_memcpy(void* dst, const void* src, size_t size) {
-    auto dstPtr = static_cast<unsigned char*>(dst);
-    auto srcPtr = static_cast<const unsigned char*>(src);
-
-    while (size >= 4u) {
-        dstPtr[0] = srcPtr[0];
-        dstPtr[1] = srcPtr[1];
-        dstPtr[2] = srcPtr[2];
-        dstPtr[3] = srcPtr[3];
-
-        size -= 4u;
-        srcPtr += 4u;
-        dstPtr += 4u;
-    }
-    switch (size) {
-        case 3:
-            dstPtr[2] = srcPtr[2];
-        case 2:
-            dstPtr[1] = srcPtr[1];
-        case 1:
-            dstPtr[0] = srcPtr[0];
-    }
-
-    return dst;
-}
-
-static inline __device__ void* __hip_hc_memset(void* dst, unsigned char val, size_t size) {
-    auto dstPtr = static_cast<unsigned char*>(dst);
-
-    while (size >= 4u) {
-        dstPtr[0] = val;
-        dstPtr[1] = val;
-        dstPtr[2] = val;
-        dstPtr[3] = val;
-
-        size -= 4u;
-        dstPtr += 4u;
-    }
-    switch (size) {
-        case 3:
-            dstPtr[2] = val;
-        case 2:
-            dstPtr[1] = val;
-        case 1:
-            dstPtr[0] = val;
-    }
-
-    return dst;
-}
 #ifndef __OPENMP_AMDGCN__
 static inline __device__ void* memcpy(void* dst, const void* src, size_t size) {
-    return __hip_hc_memcpy(dst, src, size);
+    return __builtin_memcpy(dst, src, size);
 }
 
 static inline __device__ void* memset(void* ptr, int val, size_t size) {
-    unsigned char val8 = static_cast<unsigned char>(val);
-    return __hip_hc_memset(ptr, val8, size);
+    return __builtin_memset(ptr, val, size);
 }
 #endif // !__OPENMP_AMDGCN__
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number

SWDEV-542264

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Before device versions of memcpy and memset would rely on a manually unrolled version. This patch changes this to use __builtin_memcpy and __builtin_memset.

## Why are these changes needed?

The compiler optimizer tries to recognize common loop idioms and replace them with the associated built-in versions. We can directly the right built-in from the start. The compiler will later choose the right unroll factor on its own.

The bonus side is that it removes a bunch of code.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
