### PR TITLE
SWDEV-546808 optimize match_any() with dpp wave_rot1

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -249,7 +249,7 @@ unsigned long long __match_any(T value) {
         dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*row_mask*/, 0xf/*clmn_mask*/, 1/*bound_ctrl*/);
       else
         dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*full*/, 0xf/*full*/, 1/*bound_ctrl*/);
-      retval |= ((decltype(mask))(dill_.val == value)) << i;
+      retval |= ((unsigned long long)(dill_.val == value)) << i;
     }
     //At this point each lane has a rotated match_any mask, where it is in the LSB.
     //So we just need to rotate the mask by the lane's actual position to get the correct mask.

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -241,7 +241,7 @@ unsigned long long __match_any(T value) {
   } else {
     union dill { unsigned int i[2]; unsigned long long ill; decltype(value) val; } dill_ = { .val = value };
     retval = 1;
-    //Do a full rotate of the wave lanes, using dpp with "wave_fol1" control (ID: 0x134).
+    //Do a full rotate of the wave lanes, using dpp with "wave_rol1" control (ID: 0x134).
     //wave_rol1 dpp rotates the value from each lane to one lane right across the whole wave.
     //In doing so each lane gets a mask of matches with all other lanes in the wave.
     for (int i = 1; i < static_cast<int>(warpSize); i++) {

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -241,6 +241,9 @@ unsigned long long __match_any(T value) {
   } else {
     union dill { unsigned int i[2]; unsigned long long ill; decltype(value) val; } dill_ = { .val = value };
     retval = 1;
+    //Do a full rotate of the wave lanes, using dpp with "wave_fol1" control (ID: 0x134).
+    //wave_rol1 dpp rotates the value from each lane to one lane right across the whole wave.
+    //In doing so each lane gets a mask of matches with all other lanes in the wave.
     for (int i = 1; i < static_cast<int>(warpSize); i++) {
       if constexpr (sizeof(value) == 8)
         dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*row_mask*/, 0xf/*clmn_mask*/, 1/*bound_ctrl*/);

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -225,9 +225,9 @@ unsigned long long __match_any(T value) {
       "T can be int, unsigned int, long, unsigned long, long long, unsigned "
       "long long, float or double.");
 
-  auto actvmask = __activemask();
+  unsigned long long actvmask = __activemask();
   unsigned long long retval = 0;
-  if (actvmask != ~((decltype(actvmask))0)) {
+  if (actvmask != ~0ull) {
     bool done = false;
     while (__any(!done)) {
       if (!done) {
@@ -243,11 +243,13 @@ unsigned long long __match_any(T value) {
     retval = 1;
     for (int i = 1; i < static_cast<int>(warpSize); i++) {
       if constexpr (sizeof(value) == 8)
-        dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134, 0xf, 0xf, 0); //wave_rol1
+        dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*row_mask*/, 0xf/*clmn_mask*/, 1/*bound_ctrl*/);
       else
-        dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134, 0xf, 0xf, 0); //wave_rol1
+        dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*full*/, 0xf/*full*/, 1/*bound_ctrl*/);
       retval |= ((decltype(mask))(dill_.val == value)) << i;
     }
+    //At this point each lane has a rotated match_any mask, where it is in the LSB.
+    //So we just need to rotate the mask by the lane's actual position to get the correct mask.
     int rotv = __lane_id();
     retval = (retval << rotv) | (retval >> (static_cast<int>(warpSize) - rotv));
   }

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -225,20 +225,32 @@ unsigned long long __match_any(T value) {
       "T can be int, unsigned int, long, unsigned long, long long, unsigned "
       "long long, float or double.");
 
-  unsigned long long retval = 1;
-  union dill { unsigned int i[2]; T val; } dill_ = { .val = value };
-  dill my_dill_ = dill_;
-  for (int i = 1; i < static_cast<int>(warpSize); i++) { 
-    dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134, 0xf, 0xf, 0); //wave_rol1
-    if (dill_.i[0] != my_dill_.i[0]) continue;
-    if constexpr(sizeof(T) == 8) {
-      dill_.i[1] = __builtin_amdgcn_mov_dpp(dill_.i[1], 0x134, 0xf, 0xf, 0);
-      if (dill_.i[1] != my_dill_.i[1]) continue;
+  auto actvmask = __activemask();
+  unsigned long long retval = 0;
+  if (actvmask != ~((decltype(actvmask))0)) {
+    bool done = false;
+    while (__any(!done)) {
+      if (!done) {
+        T chosen = __hip_readfirstlane(value);
+        if (chosen == value) {
+          retval = __activemask();
+          done = true;
+        }
+      }
     }
-    retval |= (1 << i);
+  } else {
+    union dill { unsigned int i[2]; unsigned long long ill; decltype(value) val; } dill_ = { .val = value };
+    retval = 1;
+    for (int i = 1; i < static_cast<int>(warpSize); i++) {
+      if constexpr (sizeof(value) == 8)
+        dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134, 0xf, 0xf, 0); //wave_rol1
+      else
+        dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134, 0xf, 0xf, 0); //wave_rol1
+      retval |= ((decltype(mask))(dill_.val == value)) << i;
+    }
+    int rotv = __lane_id();
+    retval = (retval << rotv) | (retval >> (static_cast<int>(warpSize) - rotv));
   }
-  int rotv = __lane_id();
-  retval = (retval << rotv) | (retval >> (static_cast<int>(warpSize) - rotv));
 
   return retval;
 }

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -238,7 +238,7 @@ unsigned long long __match_any(T value) {
     retval |= (1 << i);
   }
   int rotv = __lane_id();
-  retval = (retval << rotv) | (retval >> (64 - rotv));
+  retval = (retval << rotv) | (retval >> (static_cast<int>(warpSize) - rotv));
 
   return retval;
 }

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -224,18 +224,21 @@ unsigned long long __match_any(T value) {
           (sizeof(T) == 4 || sizeof(T) == 8),
       "T can be int, unsigned int, long, unsigned long, long long, unsigned "
       "long long, float or double.");
-  bool done = false;
-  unsigned long long retval = 0;
 
-  while (__any(!done)) {
-    if (!done) {
-      T chosen = __hip_readfirstlane(value);
-      if (chosen == value) {
-        retval = __activemask();
-        done = true;
-      }
+  unsigned long long retval = 1;
+  union dill { unsigned int i[2]; T val; } dill_ = { .val = value };
+  dill my_dill_ = dill_;
+  for (int i = 1; i < static_cast<int>(warpSize); i++) { 
+    dill_.i[0] = __builtin_amdgcn_mov_dpp(dill_.i[0], 0x134, 0xf, 0xf, 0); //wave_rol1
+    if (dill_.i[0] != my_dill_.i[0]) continue;
+    if constexpr(sizeof(T) == 8) {
+      dill_.i[1] = __builtin_amdgcn_mov_dpp(dill_.i[1], 0x134, 0xf, 0xf, 0);
+      if (dill_.i[1] != my_dill_.i[1]) continue;
     }
+    retval |= (1 << i);
   }
+  int rotv = __lane_id();
+  retval = (retval << rotv) | (retval >> (64 - rotv));
 
   return retval;
 }

--- a/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -242,8 +242,8 @@ unsigned long long __match_any(T value) {
     union dill { unsigned int i[2]; unsigned long long ill; decltype(value) val; } dill_ = { .val = value };
     retval = 1;
     //Do a full rotate of the wave lanes, using dpp with "wave_rol1" control (ID: 0x134).
-    //wave_rol1 dpp rotates the value from each lane to one lane right across the whole wave.
-    //In doing so each lane gets a mask of matches with all other lanes in the wave.
+    //wave_rol1 dpp rotates the value from each lane to one lane left of it, across the whole wave.
+    //In doing so each lane gets a mask of matches with all other lanes in the wave in retval.
     for (int i = 1; i < static_cast<int>(warpSize); i++) {
       if constexpr (sizeof(value) == 8)
         dill_.ill = __builtin_amdgcn_mov_dpp(dill_.ill, 0x134 /*dpp_ctrl=wave_rol1*/, 0xf/*row_mask*/, 0xf/*clmn_mask*/, 1/*bound_ctrl*/);


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Fixes SWDEV-546808

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
match_any() showing suboptimal perf. This change converts it to a sequence of wave_rot1 dpp ops.

## Why are these changes needed?
Prior solution uses inefficient firstlane in loop.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
