### PR TITLE
Fix build with LLD 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         add_compile_options(/MTd)
         add_compile_options(-D_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH)
     endif()
+else()
+    add_link_options("-Wl,--undefined-version")
 endif()
 
 if (AMD_COMPUTE_WIN)


### PR DESCRIPTION
ld.lld recently changed its default to be to error on undefined symbols.  This PR adds an option to restore the previous behavior and therefore allow the build to succeed with newer versions of lld.
