### PR TITLE
SWDEV-1 - Return error if memory segment corresponding to a flag is n…

### DIFF
--- a/rocclr/device/rocm/rocdevice.cpp
+++ b/rocclr/device/rocm/rocdevice.cpp
@@ -2223,10 +2223,14 @@ void Device::releaseMemory(void* ptr, size_t size) const {
 void* Device::deviceLocalAlloc(size_t size, bool atomics, bool pseudo_fine_grain,
                                bool contiguous) const {
 
-  const hsa_amd_memory_pool_t& pool = (pseudo_fine_grain && gpu_ext_fine_grained_segment_.handle)
-                                       ? gpu_ext_fine_grained_segment_
-                                         : (atomics && gpu_fine_grained_segment_.handle)
-                                            ? gpu_fine_grained_segment_ : gpuvm_segment_;
+  if ((pseudo_fine_grain && !gpu_ext_fine_grained_segment_.handle)
+      || (atomics && !gpu_fine_grained_segment_.handle)) {
+    LogError("Cannot allocate pseudo fine grain or atomics on right segment");
+    return nullptr;
+  }
+
+  const hsa_amd_memory_pool_t& pool = pseudo_fine_grain ? gpu_ext_fine_grained_segment_
+                                         : atomics ? gpu_fine_grained_segment_ : gpuvm_segment_;
 
   if (pool.handle == 0 || gpuvm_segment_max_alloc_ == 0) {
     DevLogPrintfError("Invalid argument, pool_handle: 0x%x , max_alloc: %u \n",


### PR DESCRIPTION
…ot available.

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->
Avoid falling back on general memory segment in case of atomics or pseudo fine grain segment not available.

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->
Other wise hipExtMallocWithFlags will not return error.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [X ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ X] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
