### PR TITLE
SWDEV-465041 - Avoid GPU wait in device enqueue

### DIFF
--- a/rocclr/device/rocm/rocblit.cpp
+++ b/rocclr/device/rocm/rocblit.cpp
@@ -2738,7 +2738,8 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM,
 
   amd::NDRangeContainer ndrange(1, globalWorkOffset, globalWorkSize, localWorkSize);
 
-  device::Kernel* devKernel = const_cast<device::Kernel*>(kernels_[Scheduler]->getDeviceKernel(dev()));
+  device::Kernel* devKernel = const_cast<device::Kernel*>(
+    kernels_[Scheduler]->getDeviceKernel(dev()));
   Kernel& gpuKernel = static_cast<Kernel&>(*devKernel);
 
   auto* sp = reinterpret_cast<SchedulerParam*>(
@@ -2756,8 +2757,12 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM,
     sp->eng_clk = (1000 * 1024) / dev().info().maxEngineClockFrequency_;
   }
 
-  // Use a device side global atomics to workaround the reliance of PCIe 3 atomics
-  sp->write_index = hsa_queue_load_write_index_relaxed(schedulerQueue);
+  if (!dev().info().pcie_atomics_) {
+    // Use a device side global atomics to workaround the reliance of PCIe 3 atomics
+    sp->write_index = hsa_queue_load_write_index_relaxed(schedulerQueue);
+  } else {
+    sp->write_index = static_cast<uint64_t>(-1ULL);
+  }
 
   constexpr bool kDirectVa = true;
   setArgument(kernels_[Scheduler], 0, sizeof(cl_mem), sp, 0, nullptr, kDirectVa);
@@ -2771,14 +2776,17 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM,
   releaseArguments(parameters);
   // Wait for the scheduler to finish all operations
   gpu().WaitCompleteSignal(sp->complete_signal);
-  // @note: A wait shouldn't be really necessary, but the queue write_index may not get a proper
-  // value without the wait for all previous commands (see the PCIE3 atomics workaround above).
-  // The scheduler can enqueue extra commands, but the real queue write index didn't have any
-  // progress. That leads to hangs and requires blocking. Then the wait causes problems in DD mode
-  // with device enqueue and user events, because device enqueue is blocking below
-  if (!WaitForSignal(sp->complete_signal)) {
-    LogWarning("Failed schedulerSignal wait");
-    return false;
+
+  if (!dev().info().pcie_atomics_) {
+    // @note: A wait shouldn't be really necessary, but the queue write_index may not get a proper
+    // value without the wait for all previous commands (see the PCIE3 atomics workaround above).
+    // The scheduler can enqueue extra commands, but the real queue write index didn't have any
+    // progress. That leads to hangs and requires blocking. Then the wait causes problems
+    // in DD mode with device enqueue and user events, because device enqueue is blocking below
+    if (!WaitForSignal(sp->complete_signal)) {
+      LogWarning("Failed schedulerSignal wait");
+      return false;
+    }
   }
   return true;
 }


### PR DESCRIPTION
If the system has PCIE atomics, then runtime can avoid a workaround in the scheduler, which requires an explicit wait on CPU

## Associated JIRA ticket number/Github issue number
Implements SWDEV-465041 

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Disables a workaround for PCIE atomics in the device enqueue scheduler. 

## Why are these changes needed?
To avoid deadlocks with direct dispatch in OpenCL conformance tests 

## Updated CHANGELOG?
- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?
- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks
- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
