### PR TITLE
SWDEV-549707 - Fixed memleak in hipMemImportFromShareableHandle

### DIFF
--- a/hipamd/src/hip_vm.cpp
+++ b/hipamd/src/hip_vm.cpp
@@ -257,8 +257,8 @@ hipError_t hipMemImportFromShareableHandle(hipMemGenericAllocationHandle_t* hand
   phys_mem_obj->getUserData().data = new hip::GenericAllocation(*phys_mem_obj, 0, prop);
   *handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(phys_mem_obj->getUserData().data);
 
-  if (amd::MemObjMap::FindMemObj(phys_mem_obj->getSvmPtr())) {
-    amd::MemObjMap::RemoveMemObj(phys_mem_obj->getSvmPtr());
+  if (!amd::MemObjMap::FindMemObj(phys_mem_obj->getSvmPtr())) {
+    amd::MemObjMap::AddMemObj(phys_mem_obj->getSvmPtr(), phys_mem_obj);
   }
 
   HIP_RETURN(hipSuccess);


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Fixes SWDEV-549707
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Release the phys_mem_ref_ when the GenericAllocation gets released
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
Fix a mem leak in vmm tests
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
