### PR TITLE
SWDEV-548482 - Address memory leaks in memory tests

### DIFF
--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -1872,10 +1872,6 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
       }
     }
 
-    if (!waitList.empty()) {
-      waitList[0]->release();
-    }
-
     amd::ReadMemoryCommand* readCommand =
       new amd::ReadMemoryCommand(*stream, CL_COMMAND_READ_BUFFER_RECT, waitList,
                                  *srcMemory, srcStart, copyRegion, dstHost, srcRect, dstRect,
@@ -1889,6 +1885,10 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
       return hipErrorInvalidValue;
     }
     command = readCommand;
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
+    }
   }
 
   return hipSuccess;
@@ -2016,10 +2016,6 @@ hipError_t ihipMemcpyHtoACommand(amd::Command*& command, amd::Image* dstImage,
       }
     }
 
-    if (!waitList.empty()) {
-      waitList[0]->release();
-    }
-
     amd::WriteMemoryCommand* writeMemCmd = new amd::WriteMemoryCommand(
       *pStream, CL_COMMAND_WRITE_IMAGE, waitList, *dstImage, dstOrigin,
       copyRegion, static_cast<const char*>(srcHost) + start, srcRowPitch, srcSlicePitch,
@@ -2033,6 +2029,10 @@ hipError_t ihipMemcpyHtoACommand(amd::Command*& command, amd::Image* dstImage,
       return hipErrorInvalidValue;
     }
     command = writeMemCmd;
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
+    }
   }
 
   return hipSuccess;
@@ -2069,10 +2069,6 @@ hipError_t ihipMemcpyAtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
       }
     }
 
-    if (!waitList.empty()) {
-      waitList[0]->release();
-    }
-
     amd::ReadMemoryCommand* readMemCmd = new amd::ReadMemoryCommand(
       *pStream, CL_COMMAND_READ_IMAGE, waitList, *srcImage, srcOrigin,
       copyRegion, static_cast<char*>(dstHost) + start, dstRowPitch, dstSlicePitch,
@@ -2087,6 +2083,10 @@ hipError_t ihipMemcpyAtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
       return hipErrorInvalidValue;
     }
     command = readMemCmd;
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
+    }
   }
 
   return hipSuccess;

--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -1866,7 +1866,7 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
     amd::Command::EventWaitList waitList;
     auto* pStream = hip::getNullStream(srcMemory->GetDeviceById()->context());
     if (stream != pStream) {
-      amd::Command* cmd = pStream->getLastQueuedCommand(true);
+      amd::Command* cmd = pStream->getLastQueuedCommand(false);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
@@ -2005,7 +2005,7 @@ hipError_t ihipMemcpyHtoACommand(amd::Command*& command, amd::Image* dstImage,
     amd::Command::EventWaitList waitList;
     if (queueDevice != dstImage->GetDeviceById()) {
       pStream = hip::getNullStream(dstImage->GetDeviceById()->context());
-      amd::Command* cmd = stream->getLastQueuedCommand(true);
+      amd::Command* cmd = stream->getLastQueuedCommand(false);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
@@ -2054,7 +2054,7 @@ hipError_t ihipMemcpyAtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
     amd::Command::EventWaitList waitList;
     if (queueDevice != srcImage->GetDeviceById()) {
       pStream = hip::getNullStream(srcImage->GetDeviceById()->context());
-      amd::Command* cmd = stream->getLastQueuedCommand(true);
+      amd::Command* cmd = stream->getLastQueuedCommand(false);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
@@ -4310,7 +4310,7 @@ hipError_t hipExternalMemoryGetMappedMipmappedArray(
                                    (size_t)mipmapDesc->offset, buf));
 }
 
-hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, size_t size, 
+hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, size_t size,
                                           hipMemRangeHandleType handleType,
                                           unsigned long long flags) {
   HIP_INIT_API(hipMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);

--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -1866,11 +1866,16 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
     amd::Command::EventWaitList waitList;
     auto* pStream = hip::getNullStream(srcMemory->GetDeviceById()->context());
     if (stream != pStream) {
-      amd::Command* cmd = pStream->getLastQueuedCommand(false);
+      amd::Command* cmd = pStream->getLastQueuedCommand(true);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
     }
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
+    }
+
     amd::ReadMemoryCommand* readCommand =
       new amd::ReadMemoryCommand(*stream, CL_COMMAND_READ_BUFFER_RECT, waitList,
                                  *srcMemory, srcStart, copyRegion, dstHost, srcRect, dstRect,
@@ -2005,10 +2010,14 @@ hipError_t ihipMemcpyHtoACommand(amd::Command*& command, amd::Image* dstImage,
     amd::Command::EventWaitList waitList;
     if (queueDevice != dstImage->GetDeviceById()) {
       pStream = hip::getNullStream(dstImage->GetDeviceById()->context());
-      amd::Command* cmd = stream->getLastQueuedCommand(false);
+      amd::Command* cmd = stream->getLastQueuedCommand(true);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
+    }
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
     }
 
     amd::WriteMemoryCommand* writeMemCmd = new amd::WriteMemoryCommand(
@@ -2054,10 +2063,14 @@ hipError_t ihipMemcpyAtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
     amd::Command::EventWaitList waitList;
     if (queueDevice != srcImage->GetDeviceById()) {
       pStream = hip::getNullStream(srcImage->GetDeviceById()->context());
-      amd::Command* cmd = stream->getLastQueuedCommand(false);
+      amd::Command* cmd = stream->getLastQueuedCommand(true);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
       }
+    }
+
+    if (!waitList.empty()) {
+      waitList[0]->release();
     }
 
     amd::ReadMemoryCommand* readMemCmd = new amd::ReadMemoryCommand(

--- a/hipamd/src/hip_mempool.cpp
+++ b/hipamd/src/hip_mempool.cpp
@@ -436,7 +436,7 @@ hipError_t hipMemPoolImportFromShareableHandle(
   }
 
   auto device = g_devices[0];
-  auto pool = new hip::MemoryPool(device);
+  auto pool = new hip::MemoryPool(device, nullptr, true);
   if (pool == nullptr) {
     HIP_RETURN(hipErrorOutOfMemory);
   }

--- a/hipamd/src/hip_mempool.cpp
+++ b/hipamd/src/hip_mempool.cpp
@@ -387,12 +387,16 @@ hipError_t hipMallocFromPoolAsync(
   STREAM_CAPTURE(hipMallocAsync, stream, mem_pool, size, dev_ptr);
 
   auto mpool = reinterpret_cast<hip::MemoryPool*>(mem_pool);
-  auto hip_stream = (stream == nullptr || stream == hipStreamLegacy) ?
-    hip::getCurrentDevice()->NullStream() : reinterpret_cast<hip::Stream*>(stream);
-  *dev_ptr = mpool->AllocateMemory(size, hip_stream);
-  if (*dev_ptr == nullptr) {
+  auto hip_stream = (stream == nullptr || stream == hipStreamLegacy)
+      ? hip::getCurrentDevice()->NullStream()
+      : reinterpret_cast<hip::Stream*>(stream);
+
+  auto allocated_ptr = mpool->AllocateMemory(size, hip_stream);
+  if (allocated_ptr == nullptr) {
     HIP_RETURN(hipErrorOutOfMemory);
   }
+
+  *dev_ptr = allocated_ptr;
   HIP_RETURN(hipSuccess);
 }
 

--- a/hipamd/src/hip_mempool.cpp
+++ b/hipamd/src/hip_mempool.cpp
@@ -387,16 +387,12 @@ hipError_t hipMallocFromPoolAsync(
   STREAM_CAPTURE(hipMallocAsync, stream, mem_pool, size, dev_ptr);
 
   auto mpool = reinterpret_cast<hip::MemoryPool*>(mem_pool);
-  auto hip_stream = (stream == nullptr || stream == hipStreamLegacy)
-      ? hip::getCurrentDevice()->NullStream()
-      : reinterpret_cast<hip::Stream*>(stream);
-
-  auto allocated_ptr = mpool->AllocateMemory(size, hip_stream);
-  if (allocated_ptr == nullptr) {
+  auto hip_stream = (stream == nullptr || stream == hipStreamLegacy) ?
+    hip::getCurrentDevice()->NullStream() : reinterpret_cast<hip::Stream*>(stream);
+  *dev_ptr = mpool->AllocateMemory(size, hip_stream);
+  if (*dev_ptr == nullptr) {
     HIP_RETURN(hipErrorOutOfMemory);
   }
-
-  *dev_ptr = allocated_ptr;
   HIP_RETURN(hipSuccess);
 }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-548482

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

 - When retrieving last command in ihipMemcpyXtoXCommand, there is no need to retain the command. Or if it's retained then we need to release it later by iterating over waitlist.
 - In hipMemPoolImportFromShareableHandle, MemoryPool should use physical memory

## Why are these changes needed?

All changes are made to fix memory leaks in memory tests.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
