### PR TITLE
SWDEV-548838 Add local and global fence support for barrier function

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -762,13 +762,21 @@ static void __threadfence_system()
     __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
 }
 __device__ inline static void __work_group_barrier(__cl_mem_fence_flags flags) {
-    if (flags) {
-        __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
-        __builtin_amdgcn_s_barrier();
-        __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
-    } else {
-        __builtin_amdgcn_s_barrier();
-    }
+  if (flags == (__CLK_GLOBAL_MEM_FENCE | __CLK_LOCAL_MEM_FENCE)) {
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
+    __builtin_amdgcn_s_barrier();
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+  } else if (flags & (__CLK_GLOBAL_MEM_FENCE)) {
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup", "global");
+    __builtin_amdgcn_s_barrier();
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup", "global");
+  } else if (flags & (__CLK_LOCAL_MEM_FENCE)) {
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup", "local");
+    __builtin_amdgcn_s_barrier();
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup", "local");
+  } else {
+    __builtin_amdgcn_s_barrier();
+  }
 }
 
 __device__
@@ -783,7 +791,7 @@ inline
 __attribute__((convergent))
 void __syncthreads()
 {
-  __barrier(__CLK_LOCAL_MEM_FENCE);
+  __barrier(__CLK_GLOBAL_MEM_FENCE | __CLK_LOCAL_MEM_FENCE);
 }
 
 __device__

--- a/hipamd/include/hip/amd_detail/device_library_decls.h
+++ b/hipamd/include/hip/amd_detail/device_library_decls.h
@@ -128,6 +128,7 @@ __device__ inline static __local void* __to_local(unsigned x) { return (__local 
 
 // Using hip.amdgcn.bc - sync threads
 #define __CLK_LOCAL_MEM_FENCE    0x01
+#define __CLK_GLOBAL_MEM_FENCE 0x02
 typedef unsigned __cl_mem_fence_flags;
 
 #endif


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Fixes SWDEV-548838
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Adding __CLK_LOCAL_MEM_FENCE and  __CLK_GLOBAL_MEM_FENCE support for __barrier() function. 

## Why are these changes needed?
Allow more fine-grained fence control -- also align with OpenCL standard. 


## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
