### PR TITLE
SWDEV-541427 - Fix forked stream joining to parent stream that is not…

### DIFF
--- a/hipamd/src/hip_stream.cpp
+++ b/hipamd/src/hip_stream.cpp
@@ -463,7 +463,9 @@ hipError_t hipStreamWaitEvent_common(hipStream_t stream, hipEvent_t event, unsig
     if (waitStream == nullptr) {
       return hipErrorInvalidHandle;
     }
-    if (!waitStream->IsOriginStream()) {
+    // Dont set when forked stream joins back to the parent
+    if (!waitStream->IsOriginStream() &&
+        waitStream != reinterpret_cast<hip::Stream*>(eventStream->GetParentStream())) {
       waitStream->SetCaptureGraph((eventStream)->GetCaptureGraph());
       waitStream->SetCaptureId((eventStream)->GetCaptureID());
       waitStream->SetCaptureMode((eventStream)->GetCaptureMode());


### PR DESCRIPTION
… origin stream(BeginCaptureStream)

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
SWDEV-541427

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
 Fixes forked stream joining to parent stream that is not origin stream(BeginCaptureStream)

<!-- Please give a short summary of the change. -->

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
