### PR TITLE
[Do Not Merge] C++20 for clr approach 1

### DIFF
--- a/hipamd/src/CMakeLists.txt
+++ b/hipamd/src/CMakeLists.txt
@@ -69,7 +69,7 @@ else()
 endif()
 
 set_target_properties(amdhip64 PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   POSITION_INDEPENDENT_CODE ON
@@ -77,6 +77,17 @@ set_target_properties(amdhip64 PROPERTIES
   # having hardcoded references to build/lib/libamdhip64.so
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
   ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND UNIX)
+  if(NOT DEFINED LLVM_LIBRARY_PATH)
+    set(LLVM_LIBRARY_PATH "/opt/rocm/lib/llvm/lib")
+  endif()
+  message(STATUS "Using libc++ from: ${LLVM_LIBRARY_PATH}")
+  set_target_properties(amdhip64 PROPERTIES
+    COMPILE_OPTIONS "-stdlib=libc++"
+    LINK_OPTIONS "-stdlib=libc++"
+    LINK_DIRECTORIES ${LLVM_LIBRARY_PATH})
+endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set_target_properties(amdhip64 PROPERTIES OUTPUT_NAME "amdhip64")

--- a/hipamd/src/hip_embed_pch.sh
+++ b/hipamd/src/hip_embed_pch.sh
@@ -144,17 +144,17 @@ EOF
 
   set -x
 
-  $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++17 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only --cuda-gpu-arch=gfx1030 -x hip $tmp/hip_pch.h -E >$tmp/pch_wave32.cui &&
+  $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++20 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only --cuda-gpu-arch=gfx1030 -x hip $tmp/hip_pch.h -E >$tmp/pch_wave32.cui &&
 
   cat $tmp/hip_macros.h >> $tmp/pch_wave32.cui &&
 
-  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave32.pch -x hip-cpp-output - <$tmp/pch_wave32.cui &&
+  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++20 -fgnuc-version=4.2.1 -o $tmp/hip_wave32.pch -x hip-cpp-output - <$tmp/pch_wave32.cui &&
 
-  $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++17 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only -x hip $tmp/hip_pch.h -E >$tmp/pch_wave64.cui &&
+  $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++20 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only -x hip $tmp/hip_pch.h -E >$tmp/pch_wave64.cui &&
 
   cat $tmp/hip_macros.h >> $tmp/pch_wave64.cui &&
 
-  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave64.pch -x hip-cpp-output - <$tmp/pch_wave64.cui &&
+  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++20 -fgnuc-version=4.2.1 -o $tmp/hip_wave64.pch -x hip-cpp-output - <$tmp/pch_wave64.cui &&
 
   $LLVM_DIR/bin/llvm-mc -o hip_pch.o $tmp/hip_pch.mcin --filetype=obj &&
 

--- a/hipamd/src/hiprtc/CMakeLists.txt
+++ b/hipamd/src/hiprtc/CMakeLists.txt
@@ -40,12 +40,19 @@ else()
 endif()
 
 set_target_properties(hiprtc PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   POSITION_INDEPENDENT_CODE ON
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
   ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND UNIX)
+  set_target_properties(hiprtc PROPERTIES
+    COMPILE_OPTIONS "-stdlib=libc++"
+    LINK_OPTIONS "-stdlib=libc++"
+    LINK_DIRECTORIES ${LLVM_LIBRARY_PATH})
+endif()
 
 if(WIN32)
   if(${HIP_LIB_VERSION_MAJOR} VERSION_GREATER 9)
@@ -69,12 +76,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 target_sources(hiprtc PRIVATE hiprtc.cpp ../hip_comgr_helper.cpp hiprtcInternal.cpp)
-
-set_target_properties(hiprtc PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED ON
-  CXX_EXTENSIONS OFF
-  POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(hiprtc
   PRIVATE
@@ -191,7 +192,7 @@ generate_hiprtc_mcin("${HIPRTC_GEN_MCIN}" "${HIPRTC_GEN_PREPROCESSED}")
 # Note: second command appends define macros at build time.
 add_custom_command(
   OUTPUT ${HIPRTC_GEN_PREPROCESSED}
-  COMMAND ${clang} -O3 --rocm-path=${PROJECT_SOURCE_DIR}/include/.. -std=c++17 -nogpulib --hip-version=${HIP_LIB_VERSION_MAJOR}.${HIP_LIB_VERSION_MINOR} -isystem ${HIP_COMMON_INCLUDE_DIR} -isystem ${PROJECT_SOURCE_DIR}/include -isystem ${PROJECT_BINARY_DIR}/include -isystem ${CMAKE_CURRENT_SOURCE_DIR}/include --cuda-device-only -D__HIPCC_RTC__ -DHIP_VERSION_MAJOR=${HIP_LIB_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_LIB_VERSION_MINOR} -x hip ${HIPRTC_GEN_HEADER} -E -P -o ${HIPRTC_GEN_PREPROCESSED}
+  COMMAND ${clang} -O3 --rocm-path=${PROJECT_SOURCE_DIR}/include/.. -std=c++20 -nogpulib --hip-version=${HIP_LIB_VERSION_MAJOR}.${HIP_LIB_VERSION_MINOR} -isystem ${HIP_COMMON_INCLUDE_DIR} -isystem ${PROJECT_SOURCE_DIR}/include -isystem ${PROJECT_BINARY_DIR}/include -isystem ${CMAKE_CURRENT_SOURCE_DIR}/include --cuda-device-only -D__HIPCC_RTC__ -DHIP_VERSION_MAJOR=${HIP_LIB_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_LIB_VERSION_MINOR} -x hip ${HIPRTC_GEN_HEADER} -E -P -o ${HIPRTC_GEN_PREPROCESSED}
   COMMAND ${CMAKE_COMMAND} -DHIPRTC_ADD_MACROS=1 -DHIPRTC_HEADERS="${HIPRTC_HEADERS}" -DHIPRTC_PREPROCESSED_FILE=${HIPRTC_GEN_PREPROCESSED} -P ${HIPRTC_CMAKE}
   DEPENDS ${clang} ${HIPRTC_GEN_HEADER})
 add_custom_command(
@@ -202,7 +203,7 @@ add_custom_command(
 # Create hiprtc-builtins library.
 add_library(hiprtc-builtins ${HIPRTC_GEN_OBJ})
 set_target_properties(hiprtc-builtins PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   POSITION_INDEPENDENT_CODE ON

--- a/opencl/amdocl/CMakeLists.txt
+++ b/opencl/amdocl/CMakeLists.txt
@@ -54,12 +54,16 @@ else()
 endif()
 
 set_target_properties(amdocl PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   POSITION_INDEPENDENT_CODE ON)
 
-# set amdocl library version
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(amdocl PRIVATE -stdlib=libc++ INTERFACE -stdlib=libc++)
+endif()
+
+  # set amdocl library version
 set(AMDOCL_LIB_VERSION_MAJOR "2")
 set(AMDOCL_LIB_VERSION_MINOR "1")
 if(DEFINED ENV{ROCM_LIBPATCH_VERSION})

--- a/opencl/khronos/headers/opencl2.2/CL/cl2.hpp
+++ b/opencl/khronos/headers/opencl2.2/CL/cl2.hpp
@@ -1870,82 +1870,6 @@ inline bool operator!=(const Wrapper<T> &lhs, const Wrapper<T> &rhs)
 } // namespace detail
 //! \endcond
 
-
-using BuildLogType = vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, CL_PROGRAM_BUILD_LOG>::param_type>>;
-#if defined(CL_HPP_ENABLE_EXCEPTIONS)
-/**
-* Exception class for build errors to carry build info
-*/
-class BuildError : public Error
-{
-private:
-    BuildLogType buildLogs;
-public:
-    BuildError(cl_int err, const char * errStr, const BuildLogType &vec) : Error(err, errStr), buildLogs(vec)
-    {
-    }
-
-    BuildLogType getBuildLog() const
-    {
-        return buildLogs;
-    }
-};
-namespace detail {
-    static inline cl_int buildErrHandler(
-        cl_int err,
-        const char * errStr,
-        const BuildLogType &buildLogs)
-    {
-        if (err != CL_SUCCESS) {
-            throw BuildError(err, errStr, buildLogs);
-        }
-        return err;
-    }
-} // namespace detail
-
-#else
-namespace detail {
-    static inline cl_int buildErrHandler(
-        cl_int err,
-        const char * errStr,
-        const BuildLogType &buildLogs)
-    {
-        (void)buildLogs; // suppress unused variable warning
-        (void)errStr;
-        return err;
-    }
-} // namespace detail
-#endif // #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-
-
-/*! \stuct ImageFormat
- *  \brief Adds constructors and member functions for cl_image_format.
- *
- *  \see cl_image_format
- */
-struct ImageFormat : public cl_image_format
-{
-    //! \brief Default constructor - performs no initialization.
-    ImageFormat(){}
-
-    //! \brief Initializing constructor.
-    ImageFormat(cl_channel_order order, cl_channel_type type)
-    {
-        image_channel_order = order;
-        image_channel_data_type = type;
-    }
-
-    //! \brief Assignment operator.
-    ImageFormat& operator = (const ImageFormat& rhs)
-    {
-        if (this != &rhs) {
-            this->image_channel_data_type = rhs.image_channel_data_type;
-            this->image_channel_order     = rhs.image_channel_order;
-        }
-        return *this;
-    }
-};
-
 /*! \brief Class interface for cl_device_id.
  *
  *  \note Copies of these objects are inexpensive, since they don't 'own'
@@ -2178,6 +2102,81 @@ public:
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag Device::default_initialized_;
 CL_HPP_DEFINE_STATIC_MEMBER_ Device Device::default_;
 CL_HPP_DEFINE_STATIC_MEMBER_ cl_int Device::default_error_ = CL_SUCCESS;
+
+using BuildLogType = vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, CL_PROGRAM_BUILD_LOG>::param_type>>;
+#if defined(CL_HPP_ENABLE_EXCEPTIONS)
+/**
+* Exception class for build errors to carry build info
+*/
+class BuildError : public Error
+{
+private:
+    BuildLogType buildLogs;
+public:
+    BuildError(cl_int err, const char * errStr, const BuildLogType &vec) : Error(err, errStr), buildLogs(vec)
+    {
+    }
+
+    BuildLogType getBuildLog() const
+    {
+        return buildLogs;
+    }
+};
+namespace detail {
+    static inline cl_int buildErrHandler(
+        cl_int err,
+        const char * errStr,
+        const BuildLogType &buildLogs)
+    {
+        if (err != CL_SUCCESS) {
+            throw BuildError(err, errStr, buildLogs);
+        }
+        return err;
+    }
+} // namespace detail
+
+#else
+namespace detail {
+    static inline cl_int buildErrHandler(
+        cl_int err,
+        const char * errStr,
+        const BuildLogType &buildLogs)
+    {
+        (void)buildLogs; // suppress unused variable warning
+        (void)errStr;
+        return err;
+    }
+} // namespace detail
+#endif // #if defined(CL_HPP_ENABLE_EXCEPTIONS)
+
+
+/*! \stuct ImageFormat
+ *  \brief Adds constructors and member functions for cl_image_format.
+ *
+ *  \see cl_image_format
+ */
+struct ImageFormat : public cl_image_format
+{
+    //! \brief Default constructor - performs no initialization.
+    ImageFormat(){}
+
+    //! \brief Initializing constructor.
+    ImageFormat(cl_channel_order order, cl_channel_type type)
+    {
+        image_channel_order = order;
+        image_channel_data_type = type;
+    }
+
+    //! \brief Assignment operator.
+    ImageFormat& operator = (const ImageFormat& rhs)
+    {
+        if (this != &rhs) {
+            this->image_channel_data_type = rhs.image_channel_data_type;
+            this->image_channel_order     = rhs.image_channel_order;
+        }
+        return *this;
+    }
+};
 
 /*! \brief Class interface for cl_platform_id.
  *

--- a/rocclr/cmake/ROCclr.cmake
+++ b/rocclr/cmake/ROCclr.cmake
@@ -51,10 +51,14 @@ set(ROCCLR_INCLUDE_DIR "${ROCCLR_SRC_DIR}/include" PARENT_SCOPE)
 mark_as_advanced(ROCCLR_INCLUDE_DIR)
 
 set_target_properties(rocclr PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(rocclr PRIVATE -stdlib=libc++ INTERFACE -stdlib=libc++)
+endif()
 
 target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/compiler/lib/utils/options.cpp

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -e
+
+function print_help() {
+  echo "Help:"
+  echo "--build-hip           : build hip"
+  echo "--build-opencl        : build opencl"
+  echo "--build-all           : build both opencl and hip"
+  echo "--rocm-path=<path>    : pass rocm path for clang search, defaults to /opt/rocm"
+  echo "--install-path=<path> : install path, defaults to build/install"
+  echo "--build-only          : just build, defaults to off"
+}
+
+declare -a input_args=("$@")
+
+DEFAULT_ROCM_PATH="/opt/rocm"
+BUILD_HIP=0
+BUILD_OPENCL=0
+DEFAULT_HIP_HEADER_PATH="$(pwd)/../hip"
+CMAKE_OPTIONS=""
+DEFAULT_INSTALL_PATH="$(pwd)/build/install"
+BUILD_ONLY=0
+
+for arg in "${input_args[@]}"; do
+  if [[ $arg == "--help" || $arg == "-h" ]]; then
+    print_help
+    exit 0
+  fi
+  if [ $arg == "--build-hip" ]; then
+    BUILD_HIP=1
+    continue
+  fi
+  if [ $arg == "--build-opencl" ]; then
+    BUILD_OPENCL=1
+    continue
+  fi
+  if [ $arg == "--build-all" ]; then
+    BUILD_HIP=1
+    BUILD_OPENCL=1
+    continue
+  fi
+  if [ $arg == "--build-only" ]; then
+    BUILD_ONLY=1
+    continue
+  fi
+  if [[ $arg == "--rocm-path="* ]]; then
+    TEMP_ARG="--rocm-path="
+    DEFAULT_ROCM_PATH="${arg/$TEMP_ARG/}"
+  fi
+  if [[ $arg == "--hip-header="* ]]; then
+    TEMP_ARG="--hip-header="
+    DEFAULT_HIP_HEADER_PATH="${arg/$TEMP_ARG/}"
+  fi
+  if [[ $arg == "install-path="* ]]; then
+    TEMP_ARG="install-path="
+    DEFAULT_INSTALL_PATH="${arg/$TEMP_ARG/}"
+  fi
+done
+
+CLANG_C_PATH=$DEFAULT_ROCM_PATH"/llvm/bin/clang"
+CLANG_CXX_PATH=$DEFAULT_ROCM_PATH"/llvm/bin/clang++"
+LLVM_LIBRARY_PATH="$DEFAULT_ROCM_PATH/lib/llvm/lib"
+
+if [ -z "$CLANG_CXX_PATH" ]; then
+  echo "Can not find clang at path: $CLANG_CXX_PATH"
+  exit 1
+fi
+
+if [[ "$BUILD_HIP" -eq 0 && "$BUILD_OPENCL" -eq 0 ]]; then
+  echo "pass --build-hip, --build-opencl or --build-all to the script"
+  exit 1
+fi
+
+if [ $BUILD_HIP -eq 1 ]; then
+  CMAKE_OPTIONS+=" -DCLR_BUILD_HIP=ON"
+fi
+if [ $BUILD_OPENCL -eq 1 ]; then
+  CMAKE_OPTIONS+=" -DCLR_BUILD_OCL=ON"
+fi
+CMAKE_OPTIONS+=" -DHIP_COMMON_DIR=${DEFAULT_HIP_HEADER_PATH}"
+CMAKE_OPTIONS+=" -DCMAKE_INSTALL_PREFIX=${DEFAULT_INSTALL_PATH}"
+
+echo "-------------Configure script---------------"
+echo "--- ROCm Path:          ${DEFAULT_ROCM_PATH}"
+echo "--- Found Clang C++ at: ${CLANG_CXX_PATH}"
+echo "--- Found Clang C at:   ${CLANG_C_PATH}"
+echo "--- Building HIP:       ${BUILD_HIP}"
+echo "--- Building OpenCL:    ${BUILD_OPENCL}"
+echo "--- HIP Header arg:     ${DEFAULT_HIP_HEADER_PATH}"
+echo "--- Install Path:       ${DEFAULT_INSTALL_PATH}"
+echo "--- CMake arg:          ${CMAKE_OPTIONS}"
+echo "--- LLVM Library Path:  ${LLVM_LIBRARY_PATH}"
+echo "--------------------------------------------"
+
+mkdir -p build
+cd build
+
+cmake -DCMAKE_C_COMPILER="$CLANG_C_PATH" \
+      -DCMAKE_CXX_COMPILER="$CLANG_CXX_PATH" \
+      -DLLVM_LIBRARY_PATH="$LLVM_LIBRARY_PATH" \
+      $CMAKE_OPTIONS \
+      ..
+
+if [ $BUILD_ONLY -eq 1 ]; then
+  make -j$(nproc)
+else
+  make -j$(nproc) install
+fi


### PR DESCRIPTION
Use C++20 for building CLR.
Add a configure script which can be used to build clr.
This will help us avoid unnecessary checks for OS's and keep the CMake script as is.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
