### PR TITLE
SWDEV-491532 - handle clang-cl + SWDEV-545259 - Missing proper DLL entry points for a few symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,20 @@ project(clr)
 ##########
 # Defaults
 ##########
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+    OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
     add_compile_options("/wd4267" "/wd4244" "/wd4996")
     string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     string(REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(/MTd)
         add_compile_options(-D_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        # Unlike when targeting MSFT's MSVC, when targeting clang-cl,
+        # CMake does not add these automatically.  Add them ourselves.
+        add_compile_options("/DWIN32" "/D_WINDOWS" "/EHsc")
     endif()
 endif()
 

--- a/hipamd/src/hip_table_interface.cpp
+++ b/hipamd/src/hip_table_interface.cpp
@@ -244,6 +244,11 @@ hipError_t hipDeviceGetStreamPriorityRange(int* leastPriority, int* greatestPrio
   return hip::GetHipDispatchTable()->hipDeviceGetStreamPriorityRange_fn(leastPriority,
                                                                         greatestPriority);
 }
+hipError_t hipDeviceGetTexture1DLinearMaxWidth(size_t* maxWidthInElements,
+                                               const hipChannelFormatDesc* fmtDesc, int device) {
+  return hip::GetHipDispatchTable()->hipDeviceGetTexture1DLinearMaxWidth_fn(maxWidthInElements,
+                                                                            fmtDesc, device);
+}
 hipError_t hipDeviceGetUuid(hipUUID* uuid, hipDevice_t device) {
   return hip::GetHipDispatchTable()->hipDeviceGetUuid_fn(uuid, device);
 }
@@ -482,6 +487,50 @@ hipError_t hipGraphAddEventRecordNode(hipGraphNode_t* pGraphNode, hipGraph_t gra
                                       hipEvent_t event) {
   return hip::GetHipDispatchTable()->hipGraphAddEventRecordNode_fn(pGraphNode, graph, pDependencies,
                                                                    numDependencies, event);
+}
+hipError_t hipGraphAddExternalSemaphoresSignalNode(
+    hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies,
+    size_t numDependencies, const hipExternalSemaphoreSignalNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphAddExternalSemaphoresSignalNode_fn(
+      pGraphNode, graph, pDependencies, numDependencies, nodeParams);
+}
+hipError_t hipGraphAddExternalSemaphoresWaitNode(
+    hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies,
+    size_t numDependencies, const hipExternalSemaphoreWaitNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphAddExternalSemaphoresWaitNode_fn(
+      pGraphNode, graph, pDependencies, numDependencies, nodeParams);
+}
+hipError_t hipGraphExternalSemaphoresSignalNodeSetParams(
+    hipGraphNode_t hNode, const hipExternalSemaphoreSignalNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphExternalSemaphoresSignalNodeSetParams_fn(hNode,
+                                                                                      nodeParams);
+}
+hipError_t hipGraphExternalSemaphoresSignalNodeGetParams(
+    hipGraphNode_t hNode, hipExternalSemaphoreSignalNodeParams* params_out) {
+  return hip::GetHipDispatchTable()->hipGraphExternalSemaphoresSignalNodeGetParams_fn(hNode,
+                                                                                      params_out);
+}
+hipError_t hipGraphExternalSemaphoresWaitNodeGetParams(
+    hipGraphNode_t hNode, hipExternalSemaphoreWaitNodeParams* params_out) {
+  return hip::GetHipDispatchTable()->hipGraphExternalSemaphoresWaitNodeGetParams_fn(hNode,
+                                                                                    params_out);
+}
+hipError_t hipGraphExternalSemaphoresWaitNodeSetParams(
+    hipGraphNode_t hNode, const hipExternalSemaphoreWaitNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphExternalSemaphoresWaitNodeSetParams_fn(hNode,
+                                                                                    nodeParams);
+}
+hipError_t hipGraphExecExternalSemaphoresSignalNodeSetParams(
+    hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
+    const hipExternalSemaphoreSignalNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphExecExternalSemaphoresSignalNodeSetParams_fn(
+      hGraphExec, hNode, nodeParams);
+}
+hipError_t hipGraphExecExternalSemaphoresWaitNodeSetParams(
+    hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
+    const hipExternalSemaphoreWaitNodeParams* nodeParams) {
+  return hip::GetHipDispatchTable()->hipGraphExecExternalSemaphoresWaitNodeSetParams_fn(
+      hGraphExec, hNode, nodeParams);
 }
 hipError_t hipGraphAddEventWaitNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
                                     const hipGraphNode_t* pDependencies, size_t numDependencies,
@@ -1880,7 +1929,7 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   return hip::GetHipDispatchTable()->hipDrvLaunchKernelEx_fn(config, f, kernel, extra);
 }
 
-hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, size_t size, 
+hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, size_t size,
                                           hipMemRangeHandleType handleType,
                                           unsigned long long flags) {
   return hip::GetHipDispatchTable()->hipMemGetHandleForAddressRange_fn(handle, dptr, size,


### PR DESCRIPTION
Change-Id: If043762b912a0c6a82951aeed620658f016bebb5## Associated JIRA ticket number/Github issue number

SWDEV-491532 - [CLR/PAL] Allow building with clang-cl on Windows
SWDEV-545259 - Missing proper DLL entry points for a few symbols

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

#1 - add CMakeLists.txt support for clang-cl.
#2 - add missing global functions for a few DLL entry points.

Please see the commit logs of the individual commits.

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

CMakeLists change need so we can build with clang-cl instead of MSVC.

Entry points needed because dispatch table.  clang-cl fails to link unless this is done properly.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

I have no idea whether you would want to advertise support for building with clang-cl.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

Ditto.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.

This depends on https://github.com/AMD-ROCm-Internal/hip/pull/280 .  Without that, clang-cl notices that the declaration of hipDeviceGetTexture1DLinearMaxWidth in include/hip/hip_runtime_api.h in the hip repo does not match the definition in clr.