### PR TITLE
SWDEV-516613 - Fixes for OpenCL printf conformance test failures

### DIFF
--- a/rocclr/device/pal/palprintf.cpp
+++ b/rocclr/device/pal/palprintf.cpp
@@ -212,6 +212,10 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
     }
+    // modifier is "hh" or "hl" with vec size 16
+    else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
+      size = 5;
+    }
     if (size > 0) {
       curPos = size;
       pos -= curPos;
@@ -255,11 +259,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
   if (checkString(fmt.c_str())) {
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
-    //(null) should be printed
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      amd::Os::printf(fmt.data(), 0);
-      // copiedBytes = strlen("(null)")
-      copiedBytes = 6;
+      // accounts for null character
+      copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);
       amd::Os::printf(fmt.data(), argumentStr);
@@ -294,7 +296,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
           const float fArg = size == 2 ?
                             amd::half2float(*(reinterpret_cast<const uint16_t *>(argument))) :
                             *(reinterpret_cast<const float *>(argument));
-          static const char* fSpecifiers = "eEfgGa";
+          static const char* fSpecifiers = "eEfFgGaA";
           std::string fmtF = fmt;
           size_t posS = fmtF.find_first_of("%");
           size_t posE = fmtF.find_first_of(fSpecifiers);
@@ -322,13 +324,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
         } else {
           bool hhModifier = (strstr(fmt.c_str(), "hh") != nullptr);
           if (hhModifier) {
-            // current implementation of printf in gcc 4.5.2 runtime libraries, doesn`t recognize
-            // "hh" modifier ==>
-            // argument should be explicitly converted to  unsigned char (uchar) before printing and
-            // fmt should be updated not to contain "hh" modifier
-            std::string hhFmt = fmt;
-            hhFmt.erase(hhFmt.find_first_of("h"), 2);
-            amd::Os::printf(hhFmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
+            amd::Os::printf(fmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
           } else if (hlModifier) {
             amd::Os::printf(hlFmt.data(), size == 2 ?
                 *(reinterpret_cast<const uint16_t *>(argument)):
@@ -370,7 +366,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
 
 void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* workitemData,
                                 size_t& i) const {
-  static const char* specifiers = "cdieEfgGaosuxXp";
+  static const char* specifiers = "cdieEfFgGaAosuxXp";
   static const char* modifiers = "hl";
   static const char* special = "%n";
   static const std::string sepStr = "%s";
@@ -485,8 +481,14 @@ void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* 
     }
   }
 
+  // handle '%%' escapes
   if (pos != std::string::npos) {
     fmt = str.substr(pos, str.size() - pos);
+    size_t P = fmt.find("%%");
+    while (P != std::string::npos) {
+      fmt.replace(P, 2, "%");
+      P = fmt.find("%%", P);
+    }
     outputArgument(sepStr, false, ConstStr, fmt.data());
   }
 }

--- a/rocclr/device/rocm/rocprintf.cpp
+++ b/rocclr/device/rocm/rocprintf.cpp
@@ -66,9 +66,11 @@ bool PrintfDbg::checkFloat(const std::string& fmt) const {
     case 'e':
     case 'E':
     case 'f':
+    case 'F':
     case 'g':
     case 'G':
     case 'a':
+    case 'A':
       return true;
       break;
     default:
@@ -100,6 +102,10 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     // the modifier is "hh"
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
+    }
+    // modifier is "hh" or "hl" with vec size 16
+    else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
+      size = 5;
     }
     if (size > 0) {
       curPos = size;
@@ -143,11 +149,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
   if (checkString(fmt.c_str())) {
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
-    //(null) should be printed
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      amd::Os::printf(fmt.data(), 0);
-      // copiedBytes = strlen("(null)")
-      copiedBytes = 6;
+      // accounts for null character
+      copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);
       amd::Os::printf(fmt.data(), argumentStr);
@@ -182,7 +186,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
           const float fArg = size == 2 ?
                           amd::half2float(*(reinterpret_cast<const uint16_t *>(argument))) :
                           *(reinterpret_cast<const float *>(argument));
-          static const char* fSpecifiers = "eEfgGa";
+          static const char* fSpecifiers = "eEfFgGaA";
           std::string fmtF = fmt;
           size_t posS = fmtF.find_first_of("%");
           size_t posE = fmtF.find_first_of(fSpecifiers);
@@ -210,14 +214,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
         } else {
           bool hhModifier = (strstr(fmt.c_str(), "hh") != nullptr);
           if (hhModifier) {
-            // current implementation of printf in gcc 4.5.2 runtime libraries,
-            // doesn`t recognize "hh" modifier ==>
-            // argument should be explicitly converted to  unsigned char (uchar)
-            // before printing and
-            // fmt should be updated not to contain "hh" modifier
-            std::string hhFmt = fmt;
-            hhFmt.erase(hhFmt.find_first_of("h"), 2);
-            amd::Os::printf(hhFmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
+            amd::Os::printf(fmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
           } else if (hlModifier) {
             amd::Os::printf(hlFmt.data(), size == 2 ?
                 *(reinterpret_cast<const uint16_t *>(argument)):
@@ -259,7 +256,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
 
 void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* workitemData,
                                 size_t& i) const {
-  static const char* specifiers = "cdieEfgGaosuxXp";
+  static const char* specifiers = "cdieEfFgGaAosuxXp";
   static const char* modifiers = "hl";
   static const char* special = "%n";
   static const std::string sepStr = "%s";
@@ -384,8 +381,14 @@ void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* 
     }
   }
 
+  // handle '%%' escapes
   if (pos != std::string::npos) {
     fmt = str.substr(pos, str.size() - pos);
+    size_t P = fmt.find("%%", P);
+    while (P != std::string::npos) {
+      fmt.replace(P, 2, "%");
+      P = fmt.find("%%", P);
+    }
     outputArgument(sepStr, false, ConstStr, reinterpret_cast<const uint32_t*>(fmt.data()));
   }
 }


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Fixes https://ontrack-internal.amd.com/browse/SWDEV-516613

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Fixes for OpenCL conformance test failures

## Why are these changes needed?
the PR contains following fixes
1. support '%F' and '%A' conversion specifiers
2. handle "hh" or "hl" modifier with vector size 16
3. handle '%%' escapes in format string
4. Don't print "(null)" when format string is empty.

tested with latest version of CTS locally.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
