### PR TITLE
SWDEV-541623 - cuda parity hipLaunchCooperativeKernelMultiDevice and hipExtLaunchMultiKernelMultiDevice

### DIFF
--- a/hipamd/src/hip_module.cpp
+++ b/hipamd/src/hip_module.cpp
@@ -917,8 +917,11 @@ hipError_t hipLaunchCooperativeKernel_spt(const void* f, dim3 gridDim, dim3 bloc
 
 hipError_t ihipLaunchCooperativeKernelMultiDevice(hipLaunchParams* launchParamsList, int numDevices,
                                                   unsigned int flags, uint32_t extFlags) {
-  if (launchParamsList == nullptr || numDevices > g_devices.size()) {
+  if (launchParamsList == nullptr) {
     return hipErrorInvalidValue;
+  }
+  if (numDevices > g_devices.size()) {
+    return hipErrorInvalidDevice;
   }
 
   std::vector<hipFunctionLaunchParams> functionLaunchParamsList(numDevices);


### PR DESCRIPTION
err code when numDevices does not match the system devices

## Associated JIRA ticket number/Github issue number
SWDEV-541623 - error condition when numDevices does not match the system devices

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
match error code for scenario according to cuda

## Why are these changes needed?
match error code for scenario according to cuda. Cuda parity fixes

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
