### PR TITLE
SWDEV-483315 - Implement hipGraphNodeGetDependentNodes_v2

### DIFF
--- a/hipamd/include/hip/amd_detail/hip_api_trace.hpp
+++ b/hipamd/include/hip/amd_detail/hip_api_trace.hpp
@@ -405,6 +405,10 @@ typedef hipError_t (*t_hipGraphNodeGetDependencies)(hipGraphNode_t node,
 typedef hipError_t (*t_hipGraphNodeGetDependentNodes)(hipGraphNode_t node,
                                                       hipGraphNode_t* pDependentNodes,
                                                       size_t* pNumDependentNodes);
+typedef hipError_t (*t_hipGraphNodeGetDependentNodes_v2)(hipGraphNode_t node,
+                                                        hipGraphNode_t* pDependentNodes,
+                                                        hipGraphEdgeData* edgeData,
+                                                        size_t* pNumDependentNodes);
 typedef hipError_t (*t_hipGraphNodeGetEnabled)(hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
                                                unsigned int* isEnabled);
 typedef hipError_t (*t_hipGraphNodeGetType)(hipGraphNode_t node, hipGraphNodeType* pType);
@@ -1589,9 +1593,10 @@ struct HipDispatchTable {
 
   // HIP_RUNTIME_API_TABLE_STEP_VERSION = 13
   // removed HIP_MEMSET_NODE_PARAMS replaced by hipMemsetParams
+  t_hipGraphNodeGetDependentNodes_v2 hipGraphNodeGetDependentNodes_v2_fn;
 
   // DO NOT EDIT ABOVE!
-  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 13
+  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 14
 
   // ******************************************************************************************* //
   //

--- a/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -438,7 +438,8 @@ enum hip_api_id_t {
   HIP_API_ID_hipLinkDestroy = 418,
   HIP_API_ID_hipLaunchKernelExC = 419,
   HIP_API_ID_hipDrvLaunchKernelEx = 420,
-  HIP_API_ID_LAST = 420,
+  HIP_API_ID_hipGraphNodeGetDependentNodes_V2 = 421,
+  HIP_API_ID_LAST = 421,
 
   HIP_API_ID_hipChooseDevice = HIP_API_ID_CONCAT(HIP_API_ID_,hipChooseDevice),
   HIP_API_ID_hipGetDeviceProperties = HIP_API_ID_CONCAT(HIP_API_ID_,hipGetDeviceProperties),
@@ -672,6 +673,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphNodeFindInClone: return "hipGraphNodeFindInClone";
     case HIP_API_ID_hipGraphNodeGetDependencies: return "hipGraphNodeGetDependencies";
     case HIP_API_ID_hipGraphNodeGetDependentNodes: return "hipGraphNodeGetDependentNodes";
+    case HIP_API_ID_hipGraphNodeGetDependentNodes_V2: return "hipGraphNodeGetDependentNodes_v2";
     case HIP_API_ID_hipGraphNodeGetEnabled: return "hipGraphNodeGetEnabled";
     case HIP_API_ID_hipGraphNodeGetType: return "hipGraphNodeGetType";
     case HIP_API_ID_hipGraphNodeSetEnabled: return "hipGraphNodeSetEnabled";
@@ -1087,6 +1089,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphNodeFindInClone", name) == 0) return HIP_API_ID_hipGraphNodeFindInClone;
   if (strcmp("hipGraphNodeGetDependencies", name) == 0) return HIP_API_ID_hipGraphNodeGetDependencies;
   if (strcmp("hipGraphNodeGetDependentNodes", name) == 0) return HIP_API_ID_hipGraphNodeGetDependentNodes;
+  if (strcmp("hipGraphNodeGetDependentNodes_v2", name) == 0) return HIP_API_ID_hipGraphNodeGetDependentNodes_V2;
   if (strcmp("hipGraphNodeGetEnabled", name) == 0) return HIP_API_ID_hipGraphNodeGetEnabled;
   if (strcmp("hipGraphNodeGetType", name) == 0) return HIP_API_ID_hipGraphNodeGetType;
   if (strcmp("hipGraphNodeSetEnabled", name) == 0) return HIP_API_ID_hipGraphNodeSetEnabled;
@@ -3752,6 +3755,15 @@ typedef struct hip_api_data_s {
       unsigned int numExtSems;
       hipStream_t stream;
     } hipWaitExternalSemaphoresAsync;
+    struct {
+      hipGraphNode_t node;
+      hipGraphNode_t* pDependentNodes;
+      hipGraphNode_t pDependentNodes__val;
+      hipGraphEdgeData* edgeData;
+      hipGraphEdgeData edgeData__val;
+      size_t* pNumDependentNodes;
+      size_t pNumDependentNodes__val;
+    } hipGraphNodeGetDependentNodes_v2;
   } args;
   uint64_t *phase_data;
 } hip_api_data_t;
@@ -4863,6 +4875,13 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphNodeGetDependentNodes.node = (hipGraphNode_t)node; \
   cb_data.args.hipGraphNodeGetDependentNodes.pDependentNodes = (hipGraphNode_t*)pDependentNodes; \
   cb_data.args.hipGraphNodeGetDependentNodes.pNumDependentNodes = (size_t*)pNumDependentNodes; \
+};
+// hipGraphNodeGetDependentNodes[('hipGraphNode_t', 'node'), ('hipGraphNode_t*', 'pDependentNodes'), ('hipGraphEdgeData*', 'edgeData'), ('size_t*', 'pNumDependentNodes')]
+#define INIT_hipGraphNodeGetDependentNodes_V2_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphNodeGetDependentNodes_v2.node = (hipGraphNode_t)node; \
+  cb_data.args.hipGraphNodeGetDependentNodes_v2.pDependentNodes = (hipGraphNode_t*)pDependentNodes; \
+  cb_data.args.hipGraphNodeGetDependentNodes_v2.edgeData = (hipGraphEdgeData*)edgeData; \
+  cb_data.args.hipGraphNodeGetDependentNodes_v2.pNumDependentNodes = (size_t*)pNumDependentNodes; \
 };
 // hipGraphNodeGetEnabled[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'hNode'), ('unsigned int*', 'isEnabled')]
 #define INIT_hipGraphNodeGetEnabled_CB_ARGS_DATA(cb_data) { \
@@ -7082,6 +7101,12 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
 // hipGraphNodeGetDependentNodes[('hipGraphNode_t', 'node'), ('hipGraphNode_t*', 'pDependentNodes'), ('size_t*', 'pNumDependentNodes')]
     case HIP_API_ID_hipGraphNodeGetDependentNodes:
       if (data->args.hipGraphNodeGetDependentNodes.pDependentNodes) data->args.hipGraphNodeGetDependentNodes.pDependentNodes__val = *(data->args.hipGraphNodeGetDependentNodes.pDependentNodes);
+      if (data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes) data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes__val = *(data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes);
+      break;
+// hipGraphNodeGetDependentNodes[('hipGraphNode_t', 'node'), ('hipGraphNode_t*', 'pDependentNodes'), ('hipGraphEdgeData*', 'edgeData') ('size_t*', 'pNumDependentNodes')]
+    case HIP_API_ID_hipGraphNodeGetDependentNodes_V2:
+      if (data->args.hipGraphNodeGetDependentNodes.pDependentNodes) data->args.hipGraphNodeGetDependentNodes.pDependentNodes__val = *(data->args.hipGraphNodeGetDependentNodes.pDependentNodes);
+      if (data->args.hipGraphNodeGetDependentNodes.edgeData) data->args.hipGraphNodeGetDependentNodes.edgeData__val = *(data->args.hipGraphNodeGetDependentNodes.edgeData);
       if (data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes) data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes__val = *(data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes);
       break;
 // hipGraphNodeGetEnabled[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'hNode'), ('unsigned int*', 'isEnabled')]
@@ -9422,6 +9447,17 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << "node="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.node);
       if (data->args.hipGraphNodeGetDependentNodes.pDependentNodes == NULL) oss << ", pDependentNodes=NULL";
       else { oss << ", pDependentNodes="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.pDependentNodes__val); }
+      if (data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes == NULL) oss << ", pNumDependentNodes=NULL";
+      else { oss << ", pNumDependentNodes="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes__val); }
+      oss << ")";
+    break;
+    case HIP_API_ID_hipGraphNodeGetDependentNodes_V2:
+      oss << "hipGraphNodeGetDependentNodes(";
+      oss << "node="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.node);
+      if (data->args.hipGraphNodeGetDependentNodes.pDependentNodes == NULL) oss << ", pDependentNodes=NULL";
+      else { oss << ", pDependentNodes="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.pDependentNodes__val); }
+      if (data->args.hipGraphNodeGetDependentNodes.edgeData == NULL) oss << ", edgeData=NULL";
+      else { oss << ", edgeData="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.edgeData); }
       if (data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes == NULL) oss << ", pNumDependentNodes=NULL";
       else { oss << ", pNumDependentNodes="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphNodeGetDependentNodes.pNumDependentNodes__val); }
       oss << ")";

--- a/hipamd/src/amdhip.def
+++ b/hipamd/src/amdhip.def
@@ -492,3 +492,4 @@ hipLinkCreate
 hipLinkDestroy
 hipLaunchKernelExC
 hipDrvLaunchKernelEx
+hipGraphNodeGetDependentNodes_v2

--- a/hipamd/src/hip_api_trace.cpp
+++ b/hipamd/src/hip_api_trace.cpp
@@ -323,6 +323,8 @@ hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDep
                                        size_t* pNumDependencies);
 hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
                                          size_t* pNumDependentNodes);
+hipError_t hipGraphNodeGetDependentNodes_v2(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
+                                            hipGraphEdgeData* edgeData, size_t* pNumDependentNodes);
 hipError_t hipGraphNodeGetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
                                   unsigned int* isEnabled);
 hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType);
@@ -1043,6 +1045,7 @@ void UpdateDispatchTable(HipDispatchTable* ptrDispatchTable) {
   ptrDispatchTable->hipGraphNodeFindInClone_fn = hip::hipGraphNodeFindInClone;
   ptrDispatchTable->hipGraphNodeGetDependencies_fn = hip::hipGraphNodeGetDependencies;
   ptrDispatchTable->hipGraphNodeGetDependentNodes_fn = hip::hipGraphNodeGetDependentNodes;
+  ptrDispatchTable->hipGraphNodeGetDependentNodes_v2_fn = hip::hipGraphNodeGetDependentNodes_v2;
   ptrDispatchTable->hipGraphNodeGetEnabled_fn = hip::hipGraphNodeGetEnabled;
   ptrDispatchTable->hipGraphNodeGetType_fn = hip::hipGraphNodeGetType;
   ptrDispatchTable->hipGraphNodeSetEnabled_fn = hip::hipGraphNodeSetEnabled;
@@ -1989,13 +1992,15 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipLaunchKernelExC_fn, 474);
 HIP_ENFORCE_ABI(HipDispatchTable, hipDrvLaunchKernelEx_fn, 475);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 12
 HIP_ENFORCE_ABI(HipDispatchTable, hipMemGetHandleForAddressRange_fn, 476);
+// HIP_RUNTIME_API_TABLE_STEP_VERSION == 13
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphNodeGetDependentNodes_v2_fn, 477)
 // if HIP_ENFORCE_ABI entries are added for each new function pointer in the table, the number below
 // will be +1 of the number in the last HIP_ENFORCE_ABI line. E.g.:
 //
 //  HIP_ENFORCE_ABI(<table>, <functor>, 8)
 //
 //  HIP_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 477)
+HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 478)
 
 static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 13,
               "If you get this error, add new HIP_ENFORCE_ABI(...) code for the new function "

--- a/hipamd/src/hip_graph.cpp
+++ b/hipamd/src/hip_graph.cpp
@@ -2205,24 +2205,42 @@ hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDep
   HIP_RETURN(hipSuccess);
 }
 
-hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
-                                         size_t* pNumDependentNodes) {
-  HIP_INIT_API(hipGraphNodeGetDependentNodes, node, pDependentNodes, pNumDependentNodes);
+hipError_t ihipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
+                                          hipGraphEdgeData* edgeData, size_t* pNumDependentNodes) {
   hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(node);
   if (!hip::GraphNode::isNodeValid(n) || pNumDependentNodes == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   const std::vector<hip::GraphNode*>& dependents = n->GetEdges();
+  if (pDependentNodes && edgeData) {
+    // TODO: Update logic when support for hipGraphEdgeData is implemented
+    return hipErrorNotSupported;
+  }
   if (pDependentNodes == NULL) {
+    if (edgeData) {
+      return hipErrorInvalidValue;
+    }
+
     *pNumDependentNodes = dependents.size();
-    HIP_RETURN(hipSuccess);
+    return hipSuccess;
   } else if (*pNumDependentNodes <= dependents.size()) {
     for (int i = 0; i < *pNumDependentNodes; i++) {
-      pDependentNodes[i] = reinterpret_cast<hipGraphNode_t>(dependents[i]);
+      auto dependent = reinterpret_cast<hipGraphNode_t>(dependents[i]);
+
+      // TODO: When supported, check if edge has custom data when the support
+      // for that is implemented. If the edge has such and edgeData is NULL
+      // return hipErrorLossyQuery. The prerequisite for this to work
+      // is implementing hipGraphAddDependencies_v2 
+
+      pDependentNodes[i] = dependent;
     }
   } else {
     for (int i = 0; i < dependents.size(); i++) {
-      pDependentNodes[i] = reinterpret_cast<hipGraphNode_t>(dependents[i]);
+      auto dependent = reinterpret_cast<hipGraphNode_t>(dependents[i]);
+
+      // TODO: Same as above
+
+      pDependentNodes[i] = dependent;
     }
     // pNumDependentNodes > actual number of dependents, the remaining entries in pDependentNodes
     // will be set to NULL
@@ -2231,7 +2249,22 @@ hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pD
     }
     *pNumDependentNodes = dependents.size();
   }
-  HIP_RETURN(hipSuccess);
+  
+  return hipSuccess;
+}
+
+hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
+                                         size_t* pNumDependentNodes) {
+  HIP_INIT_API(hipGraphNodeGetDependentNodes, node, pDependentNodes, pNumDependentNodes);
+
+  HIP_RETURN(ihipGraphNodeGetDependentNodes(node, pDependentNodes, nullptr, pNumDependentNodes));
+}
+
+hipError_t hipGraphNodeGetDependentNodes_v2(hipGraphNode_t node, hipGraphNode_t* pDependentNodes,
+                                            hipGraphEdgeData* edgeData, size_t* pNumDependentNodes) {
+  HIP_INIT_API(hipGraphNodeGetDependentNodes_V2, node, pDependentNodes, edgeData, pNumDependentNodes);
+
+  HIP_RETURN(ihipGraphNodeGetDependentNodes(node, pDependentNodes, edgeData, pNumDependentNodes));
 }
 
 hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType) {

--- a/hipamd/src/hip_hcc.map.in
+++ b/hipamd/src/hip_hcc.map.in
@@ -605,3 +605,10 @@ global:
 local:
     *;
 } hip_6.4;
+
+hip_7.1 {
+global:
+    hipGraphNodeGetDependentNodes_v2;
+local:
+    *;
+} hip_6.5;

--- a/hipamd/src/hip_table_interface.cpp
+++ b/hipamd/src/hip_table_interface.cpp
@@ -748,6 +748,15 @@ hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pD
   return hip::GetHipDispatchTable()->hipGraphNodeGetDependentNodes_fn(node, pDependentNodes,
                                                                       pNumDependentNodes);
 }
+hipError_t hipGraphNodeGetDependentNodes_v2(hipGraphNode_t node,
+                                            hipGraphNode_t* pDependentNodes,
+                                            hipGraphEdgeData* edgeData,
+                                            size_t* pNumDependentNodes) {
+  return hip::GetHipDispatchTable()->hipGraphNodeGetDependentNodes_v2_fn(node,
+                                                                         pDependentNodes,
+                                                                         edgeData,
+                                                                         pNumDependentNodes);
+}
 hipError_t hipGraphNodeGetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
                                   unsigned int* isEnabled) {
   return hip::GetHipDispatchTable()->hipGraphNodeGetEnabled_fn(hGraphExec, hNode, isEnabled);


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-483315

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Added implementation of hipGraphNodeGetDependentNodes_v2

## Why are these changes needed?

cudaGraphNodeGetDependentNodes_v2 doc reference
https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1ga8eca4a84d0902d9afe9c5b2c05093bd

## Updated CHANGELOG?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Additional Checks

- [X] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
