### PR TITLE
SWDEV-452411 - Dev/dlytovch/add bfloat16 conversions

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -108,16 +108,18 @@
 #ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
 #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BF16_H_
 
+#include <cstdint>
+#include <cstdlib>
 #if !defined(__HIPCC_RTC__)
 #include <hip/amd_detail/amd_hip_common.h>
 #include "amd_hip_vector_types.h"  // float2 etc
 #include "device_library_decls.h"  // ocml conversion functions
-#include "math_fwd.h"  // ocml device functions
+#include "math_fwd.h"              // ocml device functions
 #if defined(__clang__) and defined(__HIP__)
 #include <hip/amd_detail/amd_warp_functions.h>       // define warpSize
 #include <hip/amd_detail/amd_warp_sync_functions.h>  // Sync functions
 #endif
-#endif                // !defined(__HIPCC_RTC__)
+#endif  // !defined(__HIPCC_RTC__)
 
 #define __BF16_DEVICE__ __device__
 #if defined(__HIPCC_RTC__)
@@ -218,6 +220,407 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
   /*! \brief create __hip_bfloat16 from __bf16 */
   __BF16_HOST_DEVICE__ __hip_bfloat16(const __bf16 val) : __x_bf16(val) {}
+
+  /*! \brief create __hip_bfloat16 from an unsigned long long */
+  __hip_bfloat16(unsigned long long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return;
+    }
+
+    uint64_t abs_value = static_cast<uint64_t>(val);
+
+    int msb_pos = 0;
+    uint64_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint64_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return;
+    }
+
+    uint64_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint64_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint64_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint64_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+  }
+
+  /*! \brief create __hip_bfloat16 from an long long */
+  __hip_bfloat16(long long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return;
+    }
+
+    uint16_t sign = 0;
+    uint64_t abs_value;
+    if (val < 0) {
+      sign = 0x8000;
+      abs_value = static_cast<uint64_t>(-val);
+    } else {
+      abs_value = static_cast<uint64_t>(val);
+    }
+
+    int msb_pos = 0;
+    uint64_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint64_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return;
+    }
+
+    uint64_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint64_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint64_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint64_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+  };
+
+  /*! \brief create __hip_bfloat16 from an unsigned long */
+  __hip_bfloat16(unsigned long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return;
+    }
+
+    uint32_t abs_value = static_cast<uint32_t>(val);
+
+    int msb_pos = 0;
+    uint32_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint32_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return;
+    }
+
+    uint32_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint32_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint32_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint32_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+  };
+
+  /*! \brief create __hip_bfloat16 from an long */
+  __hip_bfloat16(long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return;
+    }
+
+    uint16_t sign = 0;
+    uint32_t abs_value;
+    if (val < 0) {
+      sign = 0x8000;
+      abs_value = static_cast<uint32_t>(-val);
+    } else {
+      abs_value = static_cast<uint32_t>(val);
+    }
+
+    int msb_pos = 0;
+    uint32_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint32_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return;
+    }
+
+    uint32_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint32_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint32_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint32_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+  };
+
+  /*! \brief assign from an unsigned long long */
+  __hip_bfloat16& operator=(unsigned long long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return *this;
+    }
+
+    uint64_t abs_value = static_cast<uint64_t>(val);
+
+    int msb_pos = 0;
+    uint64_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint64_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return *this;
+    }
+
+    uint64_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint64_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint64_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint64_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return *this;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    return *this;
+  }
+
+  /*! \brief assign from an unsigned long long */
+  __hip_bfloat16& operator=(long long val) {
+    if (val == 0) {
+      __x_bf16 = 0;
+      __x = 0;
+      return *this;
+    }
+
+    uint16_t sign = 0;
+    uint64_t abs_value;
+    if (val < 0) {
+      sign = 0x8000;
+      abs_value = static_cast<uint64_t>(-val);
+    } else {
+      abs_value = static_cast<uint64_t>(val);
+    }
+
+    int msb_pos = 0;
+    uint64_t tmp = abs_value;
+
+    while (tmp > 1) {
+      tmp >>= 1;
+      msb_pos++;
+    }
+
+    uint64_t exponent = msb_pos + 127;
+    if (exponent >= 255) {
+      __x_bf16 = 0x7F80;
+      __x = 0x7F80;
+      return *this;
+    }
+
+    uint64_t mantissa = 0;
+    if (msb_pos >= 7) {
+      int32_t shift = msb_pos - 7;
+      uint64_t mantissa_bits = abs_value >> shift;
+
+      bool round_up = false;
+      if (shift > 0) {
+        uint64_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint64_t half = 1ULL << (shift - 1);
+
+        if (remainder > half) {
+          round_up = true;
+        } else if (remainder == half) {
+          round_up = (mantissa_bits & 1) != 0;
+        }
+      }
+
+      mantissa = static_cast<uint16_t>(mantissa_bits & 0x7F);
+
+      if (round_up == true) {
+        mantissa++;
+        if (mantissa > 0x7F) {
+          mantissa = 0;
+          exponent++;
+          if (exponent >= 255) {
+            __x_bf16 = 0x7F80;
+            __x = 0x7F80;
+            return *this;
+          }
+        }
+      }
+    } else {
+      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+    }
+    __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    return *this;
+  }
 
   /*! \brief default constructor */
   __BF16_HOST_DEVICE__ __hip_bfloat16() = default;
@@ -394,7 +797,7 @@ struct __attribute__((aligned(4))) __hip_bfloat162 {
   /*! \brief return a vector of bf16 */
   __BF16_HOST_DEVICE__ operator __bf16_2() const { return __xy_bf162; }
 
-/*! \brief return a vector of bf16 */
+  /*! \brief return a vector of bf16 */
   __BF16_HOST_DEVICE__ __hip_bfloat162& operator=(const __bf16_2 in) {
     __xy_bf162 = in;
     return *this;
@@ -623,9 +1026,13 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned s
  */
 __BF16_DEVICE_STATIC__
 __hip_bfloat16 __shfl(MAYBE_UNDEF __hip_bfloat16 var, int src_lane, int width = warpSize) {
-    union { int i; __hip_bfloat16 f; } tmp; tmp.f = var;
-    tmp.i = __shfl(tmp.i, src_lane, width);
-    return tmp.f;
+  union {
+    int i;
+    __hip_bfloat16 f;
+  } tmp;
+  tmp.f = var;
+  tmp.i = __shfl(tmp.i, src_lane, width);
+  return tmp.f;
 }
 
 /**
@@ -633,11 +1040,15 @@ __hip_bfloat16 __shfl(MAYBE_UNDEF __hip_bfloat16 var, int src_lane, int width = 
  * \brief shfl up warp intrinsic for bfloat16
  */
 __BF16_DEVICE_STATIC__
-__hip_bfloat16 __shfl_up(MAYBE_UNDEF __hip_bfloat16 var,
-                         unsigned int lane_delta, int width = warpSize) {
-    union { int i; __hip_bfloat16 f; } tmp; tmp.f = var;
-    tmp.i = __shfl_up(tmp.i, lane_delta, width);
-    return tmp.f;
+__hip_bfloat16 __shfl_up(MAYBE_UNDEF __hip_bfloat16 var, unsigned int lane_delta,
+                         int width = warpSize) {
+  union {
+    int i;
+    __hip_bfloat16 f;
+  } tmp;
+  tmp.f = var;
+  tmp.i = __shfl_up(tmp.i, lane_delta, width);
+  return tmp.f;
 }
 
 /**
@@ -645,11 +1056,15 @@ __hip_bfloat16 __shfl_up(MAYBE_UNDEF __hip_bfloat16 var,
  * \brief shfl down warp intrinsic for bfloat16
  */
 __BF16_DEVICE_STATIC__
-__hip_bfloat16 __shfl_down(MAYBE_UNDEF __hip_bfloat16 var,
-                           unsigned int lane_delta, int width = warpSize) {
-    union { int i; __hip_bfloat16 f; } tmp; tmp.f = var;
-    tmp.i = __shfl_down(tmp.i, lane_delta, width);
-    return tmp.f;
+__hip_bfloat16 __shfl_down(MAYBE_UNDEF __hip_bfloat16 var, unsigned int lane_delta,
+                           int width = warpSize) {
+  union {
+    int i;
+    __hip_bfloat16 f;
+  } tmp;
+  tmp.f = var;
+  tmp.i = __shfl_down(tmp.i, lane_delta, width);
+  return tmp.f;
 }
 
 /**
@@ -658,9 +1073,13 @@ __hip_bfloat16 __shfl_down(MAYBE_UNDEF __hip_bfloat16 var,
  */
 __BF16_DEVICE_STATIC__
 __hip_bfloat16 __shfl_xor(MAYBE_UNDEF __hip_bfloat16 var, int lane_mask, int width = warpSize) {
-    union { int i; __hip_bfloat16 f; } tmp; tmp.f = var;
-    tmp.i = __shfl_xor(tmp.i, lane_mask, width);
-    return tmp.f;
+  union {
+    int i;
+    __hip_bfloat16 f;
+  } tmp;
+  tmp.f = var;
+  tmp.i = __shfl_xor(tmp.i, lane_mask, width);
+  return tmp.f;
 }
 
 #if !defined(HIP_DISABLE_WARP_SYNC_BUILTINS)
@@ -771,7 +1190,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_xor_sync(const unsigned long long 
   u.ui = __shfl_xor_sync<unsigned long long, unsigned int>(mask, u.ui, delta, width);
   return u.bf162;
 }
-#endif // HIP_DISABLE_WARP_SYNC_BUILTINS
+#endif  // HIP_DISABLE_WARP_SYNC_BUILTINS
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
@@ -1834,17 +2253,18 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
   return old_val.h2r;
 #endif
 }
-__BF16_DEVICE_STATIC__ __hip_bfloat16 unsafeAtomicAdd(__hip_bfloat16 *address,
+__BF16_DEVICE_STATIC__ __hip_bfloat16 unsafeAtomicAdd(__hip_bfloat16* address,
                                                       __hip_bfloat16 value) {
   static_assert(sizeof(unsigned short int) == sizeof(__hip_bfloat16_raw));
-  unsigned short int* address_as_short = reinterpret_cast<unsigned short int *>(address);
+  unsigned short int* address_as_short = reinterpret_cast<unsigned short int*>(address);
   // Align to 4 bytes
-  unsigned int* aligned_addr = __builtin_bit_cast(unsigned int*,
-                               __builtin_bit_cast(unsigned long long int, address_as_short) &
-                               (unsigned long long int)(~0x3));
+  unsigned int* aligned_addr =
+      __builtin_bit_cast(unsigned int*,
+                         __builtin_bit_cast(unsigned long long int, address_as_short) &
+                             (unsigned long long int)(~0x3));
 
   bool is_lower = __builtin_bit_cast(unsigned long long int, aligned_addr) ==
-                  __builtin_bit_cast(unsigned long long int, address);
+      __builtin_bit_cast(unsigned long long int, address);
 
   __hip_bfloat162 fval;
   if (is_lower)
@@ -1852,10 +2272,9 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 unsafeAtomicAdd(__hip_bfloat16 *address,
   else
     fval = __halves2bfloat162(__float2bfloat16(0.0f), value);
 
-  __hip_bfloat162 *in = (__hip_bfloat162 *)(aligned_addr);
-  __hip_bfloat162 out =  unsafeAtomicAdd(in , fval);
-  if (is_lower)
-    return __low2bfloat16(out);
+  __hip_bfloat162* in = (__hip_bfloat162*)(aligned_addr);
+  __hip_bfloat162 out = unsafeAtomicAdd(in, fval);
+  if (is_lower) return __low2bfloat16(out);
   return __high2bfloat16(out);
 }
 #endif  // defined(__clang__) && defined(__HIP__)

--- a/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -222,9 +222,8 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
   __BF16_HOST_DEVICE__ __hip_bfloat16(const __bf16 val) : __x_bf16(val) {}
 
   /*! \brief create __hip_bfloat16 from an unsigned long long */
-  __hip_bfloat16(unsigned long long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16(unsigned long long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return;
     }
@@ -239,9 +238,8 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
       msb_pos++;
     }
 
-    uint64_t exponent = msb_pos + 127;
+    uint16_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return;
     }
@@ -249,11 +247,13 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint64_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint64_t mantissa_bits = abs_value >> shift;
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_full = abs_value & mantissa_mask;
+      uint64_t mantissa_bits = mantissa_full >> shift;
 
       bool round_up = false;
       if (shift > 0) {
-        uint64_t remainder = abs_value & ((1ULL << shift) - 1);
+        uint64_t remainder = mantissa_full & ((1ULL << shift) - 1);
         uint64_t half = 1ULL << (shift - 1);
 
         if (remainder > half) {
@@ -271,23 +271,22 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
-    __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x = (exponent << 7) | mantissa;
   }
 
   /*! \brief create __hip_bfloat16 from an long long */
-  __hip_bfloat16(long long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16(long long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return;
     }
@@ -311,7 +310,6 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
     uint64_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return;
     }
@@ -319,7 +317,9 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint64_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint64_t mantissa_bits = abs_value >> shift;
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_full = abs_value & mantissa_mask;
+      uint64_t mantissa_bits = mantissa_full >> shift;
 
       bool round_up = false;
       if (shift > 0) {
@@ -341,23 +341,22 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
     __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
   };
 
   /*! \brief create __hip_bfloat16 from an unsigned long */
-  __hip_bfloat16(unsigned long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16(unsigned long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return;
     }
@@ -374,7 +373,6 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
     uint32_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return;
     }
@@ -382,7 +380,9 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint32_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint32_t mantissa_bits = abs_value >> shift;
+      uint32_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint32_t mantissa_full = abs_value & mantissa_mask;
+      uint32_t mantissa_bits = mantissa_full >> shift;
 
       bool round_up = false;
       if (shift > 0) {
@@ -404,23 +404,22 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
     __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
   };
 
   /*! \brief create __hip_bfloat16 from an long */
-  __hip_bfloat16(long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16(long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return;
     }
@@ -444,7 +443,6 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
     uint32_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return;
     }
@@ -452,7 +450,9 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint32_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint32_t mantissa_bits = abs_value >> shift;
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_full = abs_value & mantissa_mask;
+      uint64_t mantissa_bits = mantissa_full >> shift;
 
       bool round_up = false;
       if (shift > 0) {
@@ -474,23 +474,22 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
     __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
   };
 
   /*! \brief assign from an unsigned long long */
-  __hip_bfloat16& operator=(unsigned long long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16& operator=(unsigned long long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return *this;
     }
@@ -507,7 +506,6 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
     uint64_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return *this;
     }
@@ -515,7 +513,10 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint64_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint64_t mantissa_bits = abs_value >> shift;
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_full = abs_value & mantissa_mask;
+      uint64_t mantissa_bits = mantissa_full >> shift;
+
 
       bool round_up = false;
       if (shift > 0) {
@@ -537,24 +538,23 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return *this;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
-    __x = (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = (static_cast<uint16_t>(exponent) << 7) | mantissa;
+    __x = (exponent << 7) | mantissa;
     return *this;
   }
 
   /*! \brief assign from an unsigned long long */
-  __hip_bfloat16& operator=(long long val) {
+  __BF16_HOST_DEVICE__ __hip_bfloat16& operator=(long long val) {
     if (val == 0) {
-      __x_bf16 = 0;
       __x = 0;
       return *this;
     }
@@ -578,7 +578,6 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
 
     uint64_t exponent = msb_pos + 127;
     if (exponent >= 255) {
-      __x_bf16 = 0x7F80;
       __x = 0x7F80;
       return *this;
     }
@@ -586,7 +585,9 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
     uint64_t mantissa = 0;
     if (msb_pos >= 7) {
       int32_t shift = msb_pos - 7;
-      uint64_t mantissa_bits = abs_value >> shift;
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_full = abs_value & mantissa_mask;
+      uint64_t mantissa_bits = mantissa_full >> shift;
 
       bool round_up = false;
       if (shift > 0) {
@@ -608,17 +609,17 @@ struct __attribute__((aligned(2))) __hip_bfloat16 {
           mantissa = 0;
           exponent++;
           if (exponent >= 255) {
-            __x_bf16 = 0x7F80;
             __x = 0x7F80;
             return *this;
           }
         }
       }
     } else {
-      mantissa = static_cast<uint16_t>((abs_value << (7 - msb_pos)) & 0x7F);
+      uint64_t mantissa_mask = (1ULL << msb_pos) - 1;
+      uint64_t mantissa_part = abs_value & mantissa_mask;
+      mantissa = static_cast<uint16_t>(mantissa_part << (7 - msb_pos));
     }
     __x = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
-    __x_bf16 = sign | (static_cast<uint16_t>(exponent) << 7) | mantissa;
     return *this;
   }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Closes SWDEV-452411
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Added new constructors for the bfloat16 type
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
The new conversions do not have the hardware support, so we have to implement them in software
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
