### PR TITLE
SWDEV-511239 - Remove `and` and use `&&` for preprocessors

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -113,7 +113,7 @@
 #include "amd_hip_vector_types.h"  // float2 etc
 #include "device_library_decls.h"  // ocml conversion functions
 #include "math_fwd.h"  // ocml device functions
-#if defined(__clang__) and defined(__HIP__)
+#if defined(__clang__) && defined(__HIP__)
 #include <hip/amd_detail/amd_warp_functions.h>       // define warpSize
 #include <hip/amd_detail/amd_warp_sync_functions.h>  // Sync functions
 #endif

--- a/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -190,7 +190,7 @@ template <typename T, bool is_fnuz>
 __FP8_HOST_DEVICE_STATIC__ __hip_fp8_storage_t cast_to_f8(T _x, int wm, int we, bool clip = false,
                                                           bool stoch = false,
                                                           unsigned int rng = 0) {
-#if defined(__clang__) and defined(__HIP__)
+#if defined(__clang__) && defined(__HIP__)
   constexpr bool is_half = __hip_internal::is_same<T, _Float16>::value;
   constexpr bool is_float = __hip_internal::is_same<T, float>::value;
   constexpr bool is_double = __hip_internal::is_same<T, double>::value;
@@ -198,7 +198,7 @@ __FP8_HOST_DEVICE_STATIC__ __hip_fp8_storage_t cast_to_f8(T _x, int wm, int we, 
   constexpr bool is_half = std::is_same<T, _Float16>::value;
   constexpr bool is_float = std::is_same<T, float>::value;
   constexpr bool is_double = std::is_same<T, double>::value;
-#endif  // defined(__clang__) and defined(__HIP__)
+#endif  // defined(__clang__) && defined(__HIP__)
   static_assert(is_half || is_float || is_double, "Only half, float and double can be cast to f8");
 
   const int mfmt = (sizeof(T) == 8) ? 52 : ((sizeof(T) == 4) ? 23 : 10);
@@ -403,7 +403,7 @@ after shift right by 4 bits, it would look like midpoint.
 template <typename T, bool is_fnuz>
 __FP8_HOST_DEVICE_STATIC__ T cast_from_f8(__hip_fp8_storage_t x, int wm, int we,
                                           bool clip = false) {
-#if defined(__clang__) and defined(__HIP__)
+#if defined(__clang__) && defined(__HIP__)
   constexpr bool is_half = __hip_internal::is_same<T, _Float16>::value;
   constexpr bool is_float = __hip_internal::is_same<T, float>::value;
   constexpr bool is_double = __hip_internal::is_same<T, double>::value;
@@ -411,7 +411,7 @@ __FP8_HOST_DEVICE_STATIC__ T cast_from_f8(__hip_fp8_storage_t x, int wm, int we,
   constexpr bool is_half = std::is_same<T, _Float16>::value;
   constexpr bool is_float = std::is_same<T, float>::value;
   constexpr bool is_double = std::is_same<T, double>::value;
-#endif // defined(__clang__) and defined(__HIP__)
+#endif // defined(__clang__) && defined(__HIP__)
   static_assert(is_half || is_float || is_double, "only half, float and double are supported");
 
   constexpr int weo = is_half ? 5 : (is_float ? 8 : 11);
@@ -492,7 +492,7 @@ __FP8_HOST_DEVICE_STATIC__ T cast_from_f8(__hip_fp8_storage_t x, int wm, int we,
     }
   }
 
-#if defined(__clang__) and defined(__HIP__)
+#if defined(__clang__) && defined(__HIP__)
   typename __hip_internal::conditional<
       sizeof(T) == 2, unsigned short int,
       typename __hip_internal::conditional<sizeof(T) == 4, unsigned int,

--- a/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -1553,7 +1553,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp6x32_storage_t __amd_cvt_floatx32_to_fp6x3
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp6x32_storage_t __amd_cvt_floatx32_to_fp6x32_sr_scale(
     const __amd_floatx32_storage_t val, const __amd_fp6_interpretation_t interpret,
     const unsigned int round, const __amd_scale_t scale) {
-#if __has_builtin(__builtin_amdgcn_cvt_scalef32_sr_pk32_fp6_f32) and                               \
+#if __has_builtin(__builtin_amdgcn_cvt_scalef32_sr_pk32_fp6_f32) &&                                \
     __has_builtin(__builtin_amdgcn_cvt_scalef32_sr_pk32_bf6_f32)
   return interpret == __AMD_OCP_E2M3
       ? __builtin_amdgcn_cvt_scalef32_sr_pk32_fp6_f32(val, round, __amd_scale_to_float(scale))

--- a/hipamd/include/hip/amd_detail/hip_assert.h
+++ b/hipamd/include/hip/amd_detail/hip_assert.h
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #pragma once
 
-#if defined(__clang__) and defined(__HIP__)
+#if defined(__clang__) && defined(__HIP__)
 
 // abort
 extern "C" __device__ inline __attribute__((weak))


### PR DESCRIPTION
This shows up as warning in msvc.

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Replace `and` with `&&`

## Why are these changes needed?

mscv shows them up as warnings: https://godbolt.org/z/zaE934hMK

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
