### PR TITLE
SWDEV-532052 - Auto Generated CodeQL Fix for alert 318

### DIFF
--- a/opencl/tests/ocltst/module/runtime/OCLThreadTrace.cpp
+++ b/opencl/tests/ocltst/module/runtime/OCLThreadTrace.cpp
@@ -204,7 +204,7 @@ static void DumpTraceSI(unsigned int index, cl_ushort* tracePtr,
   FILE* outFile;
   char file_name[16] = {0};
   static unsigned int iii = 0;
-  sprintf(file_name, "TTrace%d%d.out", index, iii++);
+  snprintf(file_name, sizeof(file_name), "TTrace%d%d.out", index, iii++);
 
   outFile = fopen(file_name, "w");
 


### PR DESCRIPTION
Alert#318 - Potentially overrunning write

Alert url: https://github.com/AMD-ROCm-Internal/clr/security/code-scanning/318

Explanation  
By switching from sprintf to snprintf and specifying sizeof(file_name), we ensure that no more characters are written than the buffer can hold, thereby preventing a potential buffer overflow.

Addresses: SWDEV-532052