### PR TITLE
SWDEV-538607 - Add SIMDe as a build dependency, remove naked intrinsic use.

### DIFF
--- a/cmake/FindSIMDe.cmake
+++ b/cmake/FindSIMDe.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig REQUIRED)
+if(PkgConfig_FOUND)
+    pkg_check_modules(simde IMPORTED_TARGET simde)
+endif()
+
+if(PkgConfig_FOUND AND simde_FOUND)
+    message(STATUS "Found SIMDe via pkg-config")
+    set(SIMDE_TARGET PkgConfig::SIMDE)
+else()
+    message(STATUS "SIMDe not found via pkg-config. Falling back to find_path...")
+
+    if(WIN32)
+        find_path(SIMDE_INCLUDE_DIR
+            NAMES simde/simde-common.h
+            PATHS
+                "C:/simde"
+            ENV INCLUDE
+    )
+    elseif(UNIX)
+        find_path(SIMDE_INCLUDE_DIR
+            NAMES simde/simde-common.h
+            PATHS
+                /usr/include
+                /usr/local/include
+            NO_DEFAULT_PATH
+    )
+    endif()
+
+    find_package_handle_standard_args(SIMDe
+                   REQUIRED_VARS SIMDE_INCLUDE_DIR)
+    if(SIMDE_FOUND)
+        message(STATUS "Found SIMDe headers at: ${SIMDE_INCLUDE_DIR}")
+        if(NOT TARGET SIMDE)
+            add_library(SIMDE INTERFACE)
+            target_include_directories(SIMDE INTERFACE ${SIMDE_INCLUDE_DIR})
+        endif()
+    else()
+        message(WARNING "could not find simde")
+    endif()
+endif()

--- a/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
@@ -655,15 +655,13 @@ get_native_pointer(const HIP_vector_base<T, n>& base_vec) {
       return make_vector_type<T, n>(x) /= y;
     }
 
-    template<typename T, unsigned int n>
-    __HOST_DEVICE__
-    inline
-    #if __cplusplus >= 201402L && !defined(__HIPCC_RTC__)
-    constexpr
-    #endif
-    bool operator==(
-        const HIP_vector_type<T, n>& x, const HIP_vector_type<T, n>& y) noexcept
-    {
+    template <typename T, unsigned int n>
+    __HOST_DEVICE__ inline
+#if __cplusplus >= 201402L && !defined(__HIPCC_RTC__)
+        constexpr
+#endif
+        bool
+        operator==(const HIP_vector_type<T, n>& x, const HIP_vector_type<T, n>& y) noexcept {
       bool isTrue = true;
       const auto& native_x = get_native_vector(x);
       const auto& native_y = get_native_vector(y);

--- a/hipamd/src/CMakeLists.txt
+++ b/hipamd/src/CMakeLists.txt
@@ -54,6 +54,7 @@ option(DISABLE_DIRECT_DISPATCH "Disable Direct Dispatch" OFF)
 option(BUILD_SHARED_LIBS "Build the shared library" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
 
 if(BUILD_SHARED_LIBS)
   add_library(amdhip64 SHARED)
@@ -157,31 +158,10 @@ target_compile_definitions(amdhip64 PRIVATE __HIP_PLATFORM_AMD__)
 target_link_libraries(amdhip64 PRIVATE ${OPENGL_LIBRARIES})
 target_link_libraries(amdhip64 PRIVATE ${CMAKE_DL_LIBS})
 
-find_package(PkgConfig REQUIRED)
-if (PkgConfig_FOUND)
-   pkg_check_modules(simde IMPORTED_TARGET simde)
-endif()
+find_package(SIMDe REQUIRED)
 
-if (PkgConfig_FOUND AND simde_FOUND)
-  message(STATUS "Found SIMDe via pkg-config")
-  # Link against SIMDe pseudo-target, even though it is header-only, to ensure
-  # <> inclusion.
-  target_link_libraries(amdhip64 PRIVATE PkgConfig::simde)
-else()
-  message(WARNING "SIMDe not found via pkg-config. Falling back to find_path...")
-
-  find_path(SIMDE_INCLUDE_DIR
-      NAMES simde/simde-common.h
-      PATHS
-          /usr/include
-          /usr/local/include
-      NO_DEFAULT_PATH
-  )
-
-  if (SIMDE_INCLUDE_DIR)
-    message(STATUS "Found SIMDe headers at: ${SIMDE_INCLUDE_DIR}")
-    target_include_directories(amdhip64 PRIVATE ${SIMDE_INCLUDE_DIR})
-  endif()
+if(SIMDE_FOUND)
+    target_link_libraries(amdhip64 PRIVATE ${SIMDE_TARGET})
 endif()
 
 # Add link to comgr, hsa-runtime and other required libraries in target files

--- a/hipamd/src/CMakeLists.txt
+++ b/hipamd/src/CMakeLists.txt
@@ -157,11 +157,32 @@ target_compile_definitions(amdhip64 PRIVATE __HIP_PLATFORM_AMD__)
 target_link_libraries(amdhip64 PRIVATE ${OPENGL_LIBRARIES})
 target_link_libraries(amdhip64 PRIVATE ${CMAKE_DL_LIBS})
 
-# Link against SIMDe pseudo-target, even though it is header-only, to ensure
-# <> inclusion.
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(simde REQUIRED IMPORTED_TARGET simde)
-target_link_libraries(amdhip64 PRIVATE PkgConfig::simde)
+if (PkgConfig_FOUND)
+   pkg_check_modules(simde IMPORTED_TARGET simde)
+endif()
+
+if (PkgConfig_FOUND AND simde_FOUND)
+  message(STATUS "Found SIMDe via pkg-config")
+  # Link against SIMDe pseudo-target, even though it is header-only, to ensure
+  # <> inclusion.
+  target_link_libraries(amdhip64 PRIVATE PkgConfig::simde)
+else()
+  message(WARNING "SIMDe not found via pkg-config. Falling back to find_path...")
+
+  find_path(SIMDE_INCLUDE_DIR
+      NAMES simde/simde-common.h
+      PATHS
+          /usr/include
+          /usr/local/include
+      NO_DEFAULT_PATH
+  )
+
+  if (SIMDE_INCLUDE_DIR)
+    message(STATUS "Found SIMDe headers at: ${SIMDE_INCLUDE_DIR}")
+    target_include_directories(amdhip64 PRIVATE ${SIMDE_INCLUDE_DIR})
+  endif()
+endif()
 
 # Add link to comgr, hsa-runtime and other required libraries in target files
 # This is required for static libraries

--- a/hipamd/src/CMakeLists.txt
+++ b/hipamd/src/CMakeLists.txt
@@ -156,6 +156,13 @@ target_include_directories(amdhip64
 target_compile_definitions(amdhip64 PRIVATE __HIP_PLATFORM_AMD__)
 target_link_libraries(amdhip64 PRIVATE ${OPENGL_LIBRARIES})
 target_link_libraries(amdhip64 PRIVATE ${CMAKE_DL_LIBS})
+
+# Link against SIMDe pseudo-target, even though it is header-only, to ensure
+# <> inclusion.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(simde REQUIRED IMPORTED_TARGET simde)
+target_link_libraries(amdhip64 PRIVATE PkgConfig::simde)
+
 # Add link to comgr, hsa-runtime and other required libraries in target files
 # This is required for static libraries
 if(NOT BUILD_SHARED_LIBS)

--- a/hipamd/src/hip_embed_pch.sh
+++ b/hipamd/src/hip_embed_pch.sh
@@ -142,19 +142,20 @@ __hip_pch_wave64_size:
   .long __hip_pch_wave64_size - __hip_pch_wave64
 EOF
 
+  host_triple="$(uname -m)"
   set -x
 
   $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++17 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only --cuda-gpu-arch=gfx1030 -x hip $tmp/hip_pch.h -E >$tmp/pch_wave32.cui &&
 
   cat $tmp/hip_macros.h >> $tmp/pch_wave32.cui &&
 
-  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave32.pch -x hip-cpp-output - <$tmp/pch_wave32.cui &&
+  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple "$host_triple" -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave32.pch -x hip-cpp-output - <$tmp/pch_wave32.cui &&
 
   $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++17 -nogpulib -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only -x hip $tmp/hip_pch.h -E >$tmp/pch_wave64.cui &&
 
   cat $tmp/hip_macros.h >> $tmp/pch_wave64.cui &&
 
-  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave64.pch -x hip-cpp-output - <$tmp/pch_wave64.cui &&
+  $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple "$host_triple" -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave64.pch -x hip-cpp-output - <$tmp/pch_wave64.cui &&
 
   $LLVM_DIR/bin/llvm-mc -o hip_pch.o $tmp/hip_pch.mcin --filetype=obj &&
 

--- a/hipamd/src/hip_graph_internal.cpp
+++ b/hipamd/src/hip_graph_internal.cpp
@@ -19,7 +19,7 @@
  THE SOFTWARE. */
 
 #include "hip_graph_internal.hpp"
-
+#include <cmath>
 #include <simde/x86/sse2.h>
 
 #include <queue>

--- a/hipamd/src/hip_graph_internal.cpp
+++ b/hipamd/src/hip_graph_internal.cpp
@@ -19,6 +19,9 @@
  THE SOFTWARE. */
 
 #include "hip_graph_internal.hpp"
+
+#include <simde/x86/sse2.h>
+
 #include <queue>
 
 #define CASE_STRING(X, C)                                                                          \
@@ -804,9 +807,9 @@ void GraphKernelArgManager::ReadBackOrFlush() {
       address dev_ptr =
           kernarg_graph_.back().kernarg_pool_addr_ + kernarg_graph_.back().kernarg_pool_size_;
       auto kSentinel = *reinterpret_cast<volatile unsigned char*>(dev_ptr - 1);
-      _mm_sfence();
+      simde_mm_sfence();
       *(dev_ptr - 1) = kSentinel;
-      _mm_mfence();
+      simde_mm_mfence();
       kSentinel = *reinterpret_cast<volatile unsigned char*>(dev_ptr - 1);
     }
   }

--- a/opencl/amdocl/CMakeLists.txt
+++ b/opencl/amdocl/CMakeLists.txt
@@ -42,6 +42,7 @@ if(ADDRESS_SANITIZER)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
 
 if(BUILD_SHARED_LIBS)
   add_library(amdocl SHARED)
@@ -125,6 +126,11 @@ if(WIN32)
 endif()
 
 target_link_libraries(amdocl PUBLIC rocclr)
+
+find_package(SIMDe REQUIRED)
+if(SIMDE_FOUND)
+    target_link_libraries(amdocl PRIVATE ${SIMDE_TARGET})
+endif()
 
 INSTALL(TARGETS amdocl
   COMPONENT MAIN

--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -3231,7 +3231,7 @@ bool VirtualGPU::createVirtualQueue(uint deviceQueueSize)
 __attribute__((optimize("unroll-all-loops"), always_inline))
 static inline void nontemporalMemcpy(
     void* __restrict dst, const void* __restrict src, size_t size) {
-#if defined(__AVX512F__) && false // Disable until SIMDe adds support.
+#if defined(__AVX512F__) && false  // Disable until SIMDe adds support.
   for (auto i = 0u; i != size / sizeof(simde__m512i); ++i) {
     simde_mm512_stream_si512(reinterpret_cast<simde__m512i* __restrict&>(dst)++,
                              *reinterpret_cast<const simde__m512i* __restrict&>(src)++);

--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -40,11 +40,10 @@
 
 #include <simde/x86/avx.h>
 #include <simde/x86/sse2.h>
-#if defined(SIMDE_VERSION_MAJOR) && \
-    ((SIMDE_VERSION_MAJOR > 0) || \
-    (SIMDE_VERSION_MAJOR == 0 && SIMDE_VERSION_MINOR >= 7))
+#if defined(SIMDE_VERSION_MAJOR) &&                                                                \
+    ((SIMDE_VERSION_MAJOR > 0) || (SIMDE_VERSION_MAJOR == 0 && SIMDE_VERSION_MINOR >= 7))
 
-  #include <simde/x86/avx512.h>
+#include <simde/x86/avx512.h>
 #endif
 
 

--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -38,6 +38,10 @@
 #include "hsa/amd_hsa_queue.h"
 #include "hsa/amd_hsa_signal.h"
 
+#include <simde/x86/avx.h>
+#include <simde/x86/avx512.h>
+#include <simde/x86/sse2.h>
+
 #include <fstream>
 #include <limits>
 #include <memory>
@@ -46,14 +50,6 @@
 #include <vector>
 #include <atomic>
 #include <cinttypes>
-
-#if defined(__AVX__)
-#if defined(__MINGW64__)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
-#endif
 
 /**
 * HSA image object size in bytes (see HSAIL spec)
@@ -3235,49 +3231,44 @@ bool VirtualGPU::createVirtualQueue(uint deviceQueueSize)
 __attribute__((optimize("unroll-all-loops"), always_inline))
 static inline void nontemporalMemcpy(
     void* __restrict dst, const void* __restrict src, size_t size) {
-#if defined(ATI_ARCH_X86)
-#if defined(__AVX512F__)
-  for (auto i = 0u; i != size / sizeof(__m512i); ++i) {
-    _mm512_stream_si512(reinterpret_cast<__m512i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m512i* __restrict&>(src)++);
+#if defined(__AVX512F__) && false // Disable until SIMDe adds support.
+  for (auto i = 0u; i != size / sizeof(simde__m512i); ++i) {
+    simde_mm512_stream_si512(reinterpret_cast<simde__m512i* __restrict&>(dst)++,
+                             *reinterpret_cast<const simde__m512i* __restrict&>(src)++);
   }
-  size = size % sizeof(__m512i);
+  size = size % sizeof(simde__m512i);
 #endif
 
 #if defined(__AVX__)
-  for (auto i = 0u; i != size / sizeof(__m256i); ++i) {
-    _mm256_stream_si256(reinterpret_cast<__m256i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m256i* __restrict&>(src)++);
+  for (auto i = 0u; i != size / sizeof(simde__m256i); ++i) {
+    simde_mm256_stream_si256(reinterpret_cast<simde__m256i* __restrict&>(dst)++,
+                             *reinterpret_cast<const simde__m256i* __restrict&>(src)++);
   }
-  size = size % sizeof(__m256i);
+  size = size % sizeof(simde__m256i);
 #endif
-
-  for (auto i = 0u; i != size / sizeof(__m128i); ++i) {
-    _mm_stream_si128(reinterpret_cast<__m128i* __restrict&>(dst)++,
-                     *(reinterpret_cast<const __m128i* __restrict&>(src)++));
+  for (auto i = 0u; i != size / sizeof(simde__m128i); ++i) {
+    simde_mm_stream_si128(reinterpret_cast<simde__m128i* __restrict&>(dst)++,
+                          *(reinterpret_cast<const simde__m128i* __restrict&>(src)++));
   }
-  size = size % sizeof(__m128i);
+  size = size % sizeof(simde__m128i);
 
-  for (auto i = 0u; i != size / sizeof(long long); ++i) {
-    _mm_stream_si64(reinterpret_cast<long long* __restrict&>(dst)++,
-                    *reinterpret_cast<const long long* __restrict&>(src)++);
+  for (auto i = 0u; i != size / sizeof(int64_t); ++i) {
+    simde_mm_stream_si64(reinterpret_cast<int64_t* __restrict&>(dst)++,
+                         *reinterpret_cast<const int64_t* __restrict&>(src)++);
   }
-  size = size % sizeof(long long);
+  size = size % sizeof(int64_t);
 
-  for (auto i = 0u; i != size / sizeof(int); ++i) {
-    _mm_stream_si32(reinterpret_cast<int* __restrict&>(dst)++,
-                    *reinterpret_cast<const int* __restrict&>(src)++);
+  for (auto i = 0u; i != size / sizeof(int32_t); ++i) {
+    simde_mm_stream_si32(reinterpret_cast<int32_t* __restrict&>(dst)++,
+                         *reinterpret_cast<const int32_t* __restrict&>(src)++);
   }
 
-  size = size % sizeof(int);
+  size = size % sizeof(int32_t);
   // Copy remaining bytes for unaligned size
   std::memcpy(dst, src, size);
 
   // Add memory fence
-  _mm_sfence();
-#else
-  std::memcpy(dst, src, size);
-#endif
+  simde_mm_sfence();
 }
 #else
 static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
@@ -3533,9 +3524,9 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes,
         *dev().info().hdpMemFlushCntl = 1u;
         auto kSentinel = *reinterpret_cast<volatile int*>(dev().info().hdpMemFlushCntl);
       } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback && argSize != 0) {
-        _mm_sfence();
+        simde_mm_sfence();
         *(argBuffer + argSize - 1) = *(parameters + argSize - 1);
-        _mm_mfence();
+        simde_mm_mfence();
         auto kSentinel = *reinterpret_cast<volatile unsigned char*>(argBuffer + argSize - 1);
       }
     }

--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -39,8 +39,14 @@
 #include "hsa/amd_hsa_signal.h"
 
 #include <simde/x86/avx.h>
-#include <simde/x86/avx512.h>
 #include <simde/x86/sse2.h>
+#if defined(SIMDE_VERSION_MAJOR) && \
+    ((SIMDE_VERSION_MAJOR > 0) || \
+    (SIMDE_VERSION_MAJOR == 0 && SIMDE_VERSION_MINOR >= 7))
+
+  #include <simde/x86/avx512.h>
+#endif
+
 
 #include <fstream>
 #include <limits>

--- a/rocclr/os/os.cpp
+++ b/rocclr/os/os.cpp
@@ -118,9 +118,7 @@ size_t Os::pageSize_ = 0;
 
 int Os::processorCount_ = 0;
 
-void Os::spinPause() {
-  simde_mm_pause();
-}
+void Os::spinPause() { simde_mm_pause(); }
 
 void Os::sleep(long n) {
 // FIXME_lmoriche: Should be nano-seconds not seconds.

--- a/rocclr/os/os.cpp
+++ b/rocclr/os/os.cpp
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <unistd.h>
 #endif  // !_WIN32
-
+#include <cmath>
 #include <simde/x86/sse2.h>
 
 namespace amd {

--- a/rocclr/os/os.cpp
+++ b/rocclr/os/os.cpp
@@ -31,9 +31,7 @@
 #include <unistd.h>
 #endif  // !_WIN32
 
-#if defined(ATI_ARCH_X86)
-#include <xmmintrin.h>  // for _mm_pause
-#endif                  // ATI_ARCH_X86
+#include <simde/x86/sse2.h>
 
 namespace amd {
 
@@ -121,11 +119,7 @@ size_t Os::pageSize_ = 0;
 int Os::processorCount_ = 0;
 
 void Os::spinPause() {
-#if defined(ATI_ARCH_X86)
-  _mm_pause();
-#elif defined(ATI_ARCH_ARM)
-  __asm__ __volatile__("yield");
-#endif
+  simde_mm_pause();
 }
 
 void Os::sleep(long n) {


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Fixes https://ontrack-internal.amd.com/browse/SWDEV-538607

## What type of PR is this? (check all applicable)

- [x ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Mirrored from external github PR: https://github.com/ROCm/clr/pull/170
Existing unguarded uses of x86 intrinsics are replaced with equivalent calls to generic interfaces provided by the [SIMDe library](https://github.com/simd-everywhere/simde). SIMDe itself is added as a build dependency

## Why are these changes needed?
Direct, unguarded use of architecture specific intrinsics / builtins creates challenges both when studying the library's behaviour on non-x86 targets, and when exploring different OSes.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x ] Any dependent changes have been merged.
