### PR TITLE
SWDEV-536621 - Add message to static asserts

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -152,7 +152,7 @@
 static_assert(CHAR_BIT == 8, "byte size should be of 8 bits");
 #endif
 static_assert(sizeof(unsigned short) == 2, "size of unsigned short should be 2 bytes");
-static_assert(sizeof(__bf16) == sizeof(unsigned short));
+static_assert(sizeof(__bf16) == sizeof(unsigned short), "");
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT16_RAW
@@ -347,7 +347,7 @@ typedef __bf16 __bf16_2 __attribute__((ext_vector_type(2)));
  * @{
  */
 struct __attribute__((aligned(4))) __hip_bfloat162 {
-  static_assert(sizeof(__hip_bfloat16[2]) == sizeof(__bf16_2));
+  static_assert(sizeof(__hip_bfloat16[2]) == sizeof(__bf16_2), "");
 
  public:
   union {
@@ -465,7 +465,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __bfloat162bfloat162(const __hip_bfl
  * \brief Reinterprets bits in a __hip_bfloat16 as a signed short integer
  */
 __BF16_HOST_DEVICE_STATIC__ short int __bfloat16_as_short(const __hip_bfloat16 h) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(short int));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(short int), "");
   union {
     __hip_bfloat16 bf16;
     short int si;
@@ -478,7 +478,7 @@ __BF16_HOST_DEVICE_STATIC__ short int __bfloat16_as_short(const __hip_bfloat16 h
  * \brief Reinterprets bits in a __hip_bfloat16 as an unsigned signed short integer
  */
 __BF16_HOST_DEVICE_STATIC__ unsigned short int __bfloat16_as_ushort(const __hip_bfloat16 h) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(unsigned short int));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(unsigned short int), "");
   union {
     __hip_bfloat16 bf16;
     unsigned short int usi;
@@ -596,7 +596,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __lows2bfloat162(const __hip_bfloat1
  * \brief Reinterprets short int into a bfloat16
  */
 __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __short_as_bfloat16(const short int a) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(short int));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(short int), "");
   union {
     short int si;
     __hip_bfloat16 bf16;
@@ -609,7 +609,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __short_as_bfloat16(const short int a
  * \brief Reinterprets unsigned short int into a bfloat16
  */
 __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(unsigned short int));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(unsigned short int), "");
   union {
     unsigned short int usi;
     __hip_bfloat16 bf16;
@@ -683,7 +683,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_down_sync(const unsigned long long
                                                         const __hip_bfloat162 in,
                                                         const unsigned int delta,
                                                         const int width = warpSize) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int), "");
   union {
     __hip_bfloat162 bf162;
     unsigned int ui;
@@ -709,7 +709,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 __shfl_sync(const unsigned long long mask,
 __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_sync(const unsigned long long mask,
                                                    const __hip_bfloat162 in, const int delta,
                                                    const int width = warpSize) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int), "");
   union {
     __hip_bfloat162 bf162;
     unsigned int ui;
@@ -737,7 +737,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_up_sync(const unsigned long long m
                                                       const __hip_bfloat162 in,
                                                       const unsigned int delta,
                                                       const int width = warpSize) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int), "");
   union {
     __hip_bfloat162 bf162;
     unsigned int ui;
@@ -763,7 +763,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 __shfl_xor_sync(const unsigned long long m
 __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_xor_sync(const unsigned long long mask,
                                                        const __hip_bfloat162 in, const int delta,
                                                        const int width = warpSize) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(unsigned int), "");
   union {
     __hip_bfloat162 bf162;
     unsigned int ui;
@@ -1810,7 +1810,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
                                                        __hip_bfloat162 value) {
 #if __has_builtin(__builtin_amdgcn_flat_atomic_fadd_v2bf16)
   typedef short __attribute__((ext_vector_type(2))) vec_short2;
-  static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));
+  static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw), "");
   union {
     __hip_bfloat162_raw bf162_raw;
     vec_short2 vs2;
@@ -1818,7 +1818,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
   u.vs2 = __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
   return static_cast<__hip_bfloat162>(u.bf162_raw);
 #else
-  static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
+  static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw), "");
   union u_hold {
     __hip_bfloat162_raw h2r;
     unsigned int u32;
@@ -1836,7 +1836,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
 }
 __BF16_DEVICE_STATIC__ __hip_bfloat16 unsafeAtomicAdd(__hip_bfloat16 *address,
                                                       __hip_bfloat16 value) {
-  static_assert(sizeof(unsigned short int) == sizeof(__hip_bfloat16_raw));
+  static_assert(sizeof(unsigned short int) == sizeof(__hip_bfloat16_raw), "");
   unsigned short int* address_as_short = reinterpret_cast<unsigned short int *>(address);
   // Align to 4 bytes
   unsigned int* aligned_addr = __builtin_bit_cast(unsigned int*,

--- a/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -1374,11 +1374,11 @@ THE SOFTWARE.
 	        __HOST_DEVICE__
 	        __half __habs(__half x)
 	        {
-                static_assert(sizeof(_Float16) == sizeof(unsigned short));
-                union {
-                  _Float16 fp16;
-                  unsigned short us;
-                } u{static_cast<__half_raw>(x).data};
+                  static_assert(sizeof(_Float16) == sizeof(unsigned short), "");
+                  union {
+                    _Float16 fp16;
+                    unsigned short us;
+                  } u{static_cast<__half_raw>(x).data};
                 u.us &= 0x7FFFu;
                 return __half_raw{u.fp16};
 	        }
@@ -1527,7 +1527,7 @@ THE SOFTWARE.
             #if __has_builtin(__builtin_amdgcn_flat_atomic_fadd_v2f16)
                 // The api expects an ext_vector_type of half
                 typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
-                static_assert(sizeof(vec_fp162) == sizeof(__half2_raw));
+                static_assert(sizeof(vec_fp162) == sizeof(__half2_raw), "");
                 union {
                     __half2_raw h2r;
                     vec_fp162 fp16;
@@ -1536,11 +1536,11 @@ THE SOFTWARE.
                     __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
                 return static_cast<__half2>(u.h2r);
             #else
-                static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
-                union u_hold {
-                    __half2_raw h2r;
-                    unsigned int u32;
-                };
+              static_assert(sizeof(__half2_raw) == sizeof(unsigned int), "");
+              union u_hold {
+                __half2_raw h2r;
+                unsigned int u32;
+              };
                 u_hold old_val, new_val;
                 old_val.u32 = __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED,
                                                 __HIP_MEMORY_SCOPE_AGENT);
@@ -1553,26 +1553,26 @@ THE SOFTWARE.
             #endif
             }
             inline __device__ __half unsafeAtomicAdd(__half* address, __half value) {
-                static_assert(sizeof(unsigned short int) == sizeof(__half_raw));
-                unsigned short int* address_as_short = reinterpret_cast<unsigned short int *>(address);
-                // Align to 4 bytes
-                unsigned int* aligned_addr = __builtin_bit_cast(unsigned int*,
-                                             __builtin_bit_cast(unsigned long long int, address_as_short)
-                                             & (unsigned long long int)(~0x3));
+              static_assert(sizeof(unsigned short int) == sizeof(__half_raw), "");
+              unsigned short int* address_as_short = reinterpret_cast<unsigned short int*>(address);
+              // Align to 4 bytes
+              unsigned int* aligned_addr =
+                  __builtin_bit_cast(unsigned int*,
+                                     __builtin_bit_cast(unsigned long long int, address_as_short) &
+                                         (unsigned long long int)(~0x3));
 
-                bool is_lower = __builtin_bit_cast(unsigned long long int, aligned_addr) ==
-                                __builtin_bit_cast(unsigned long long int, address);
-                __half2 fval;
-                if (is_lower)
-                  fval = __halves2half2(value, __float2half(0.0f));
-                else
-                  fval = __halves2half2(__float2half(0.0f), value);
+              bool is_lower = __builtin_bit_cast(unsigned long long int, aligned_addr) ==
+                  __builtin_bit_cast(unsigned long long int, address);
+              __half2 fval;
+              if (is_lower)
+                fval = __halves2half2(value, __float2half(0.0f));
+              else
+                fval = __halves2half2(__float2half(0.0f), value);
 
-                __half2 *in = (__half2 *)(aligned_addr);
-                __half2 out =  unsafeAtomicAdd(in , fval);
-                if (is_lower)
-                   return __low2half(out);
-                return __high2half(out);
+              __half2* in = (__half2*)(aligned_addr);
+              __half2 out = unsafeAtomicAdd(in, fval);
+              if (is_lower) return __low2half(out);
+              return __high2half(out);
             }
             #endif // defined(__clang__) && defined(__HIP__)
 

--- a/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -43,9 +43,9 @@ typedef __hip_fp8_storage_t __hip_fp4_storage_t;
 typedef __hip_fp8_storage_t __hip_fp4x2_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp4x4_storage_t;
 
-static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(uint32_t));
-static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(uint32_t));
-static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(uint32_t));
+static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(uint32_t), "");
 
 enum __hip_fp4_interpretation_t {
   __HIP_E2M1 = 0,
@@ -63,7 +63,7 @@ __FP4_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t half2_to_f16x2(const __half2 v
 }
 
 __FP4_HOST_DEVICE_STATIC__ __amd_bf16_storage_t hipbf16_to_bf16(const __hip_bfloat16 val) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t), "");
   union {
     __hip_bfloat16 hip_bf16;
     __amd_bf16_storage_t bf16;
@@ -72,7 +72,7 @@ __FP4_HOST_DEVICE_STATIC__ __amd_bf16_storage_t hipbf16_to_bf16(const __hip_bflo
 }
 
 __FP4_HOST_DEVICE_STATIC__ __amd_bf16x2_storage_t hipbf162_to_bf16x2(const __hip_bfloat162 val) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t), "");
   union {
     __hip_bfloat162 hip_bf16;
     __amd_bf16x2_storage_t bf16;
@@ -312,7 +312,7 @@ struct __hip_fp4_e2m1 {
   }
 
   __FP4_HOST_DEVICE__ operator __hip_bfloat16_raw() const {
-    static_assert(sizeof(__hip_bfloat16_raw[2]) == sizeof(__amd_bf16x2_storage_t));
+    static_assert(sizeof(__hip_bfloat16_raw[2]) == sizeof(__amd_bf16x2_storage_t), "");
     union {
       __hip_bfloat16_raw bf16_raw[2];
       __amd_bf16x2_storage_t bf16x2;
@@ -370,7 +370,7 @@ struct __hip_fp4x2_e2m1 {
   }
 
   __FP4_HOST_DEVICE__ operator __hip_bfloat162_raw() const {
-    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t));
+    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t), "");
     union {
       __hip_bfloat162_raw bf162_raw;
       __amd_bf16x2_storage_t bf16x2;

--- a/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -44,9 +44,9 @@ typedef __hip_fp8_storage_t __hip_fp6_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp6x2_storage_t;
 typedef __hip_fp8x4_storage_t __hip_fp6x4_storage_t;
 
-static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(uint32_t));
-static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(uint32_t));
-static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(uint64_t));
+static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(uint64_t), "");
 
 enum __hip_fp6_interpretation_t {
   __HIP_E3M2 = 0, /**< FP6 E3M2 Type*/
@@ -63,7 +63,7 @@ __FP6_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t half2_to_f16x2(const __half2 v
   return tmp.data;
 }
 __FP6_HOST_DEVICE_STATIC__ __amd_bf16_storage_t hipbf16_to_bf16(const __hip_bfloat16 val) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t), "");
   union {
     __hip_bfloat16 hip_bf16;
     __amd_bf16_storage_t bf16;
@@ -71,7 +71,7 @@ __FP6_HOST_DEVICE_STATIC__ __amd_bf16_storage_t hipbf16_to_bf16(const __hip_bflo
   return u.bf16;
 }
 __FP6_HOST_DEVICE_STATIC__ __amd_bf16x2_storage_t hipbf162_to_bf16x2(const __hip_bfloat162 val) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t), "");
   union {
     __hip_bfloat162 hip_bf16;
     __amd_bf16x2_storage_t bf16;
@@ -413,7 +413,7 @@ struct __hip_fp6_e2m3 {
     return __hip_cvt_fp6_to_halfraw(__x, __HIP_E2M3);
   }
   __FP6_HOST_DEVICE__ operator __hip_bfloat16_raw() const {
-    static_assert(sizeof(__hip_bfloat16_raw) == sizeof(__amd_bf16_storage_t));
+    static_assert(sizeof(__hip_bfloat16_raw) == sizeof(__amd_bf16_storage_t), "");
     union {
       __hip_bfloat16_raw bf16_raw;
       __amd_bf16_storage_t bf16;
@@ -482,7 +482,7 @@ struct __hip_fp6_e3m2 {
     return __hip_cvt_fp6_to_halfraw(__x, __HIP_E3M2);
   }
   __FP6_HOST_DEVICE__ operator __hip_bfloat16_raw() const {
-    static_assert(sizeof(__hip_bfloat16_raw) == sizeof(__amd_bf16_storage_t));
+    static_assert(sizeof(__hip_bfloat16_raw) == sizeof(__amd_bf16_storage_t), "");
     union {
       __hip_bfloat16_raw bf16_raw;
       __amd_bf16_storage_t bf16;
@@ -534,7 +534,7 @@ struct __hip_fp6x2_e2m3 {
     return __hip_cvt_fp6x2_to_halfraw2(__x, __HIP_E2M3);
   }
   __FP6_HOST_DEVICE__ operator __hip_bfloat162_raw() const {
-    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t));
+    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t), "");
     union {
       __hip_bfloat162_raw bf162_raw;
       __amd_bf16x2_storage_t bf16x2;
@@ -594,7 +594,7 @@ struct __hip_fp6x2_e3m2 {
     return __hip_cvt_fp6x2_to_halfraw2(__x, __HIP_E3M2);
   }
   __FP6_HOST_DEVICE__ operator __hip_bfloat162_raw() const {
-    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t));
+    static_assert(sizeof(__hip_bfloat162_raw) == sizeof(__amd_bf16x2_storage_t), "");
     union {
       __hip_bfloat162_raw bf162_raw;
       __amd_bf16x2_storage_t bf16x2;

--- a/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -35,10 +35,10 @@ THE SOFTWARE.
 #include <climits>
 #include <cstdio>
 
-static_assert(sizeof(uint8_t) * CHAR_BIT == 8);
-static_assert(sizeof(uint16_t) * CHAR_BIT == 16);
-static_assert(sizeof(uint32_t) * CHAR_BIT == 32);
-static_assert(sizeof(uint64_t) * CHAR_BIT == 64);
+static_assert(sizeof(uint8_t) * CHAR_BIT == 8, "");
+static_assert(sizeof(uint16_t) * CHAR_BIT == 16, "");
+static_assert(sizeof(uint32_t) * CHAR_BIT == 32, "");
+static_assert(sizeof(uint64_t) * CHAR_BIT == 64, "");
 #endif  // !defined(__HIPCC_RTC__)
 
 #include <hip/amd_detail/amd_hip_ocp_host.hpp>  // Host Conversion
@@ -151,7 +151,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_create_fp4x2(const uin
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t
 __amd_create_fp4x8(const __amd_fp4x2_storage_t x, const __amd_fp4x2_storage_t y,
                    const __amd_fp4x2_storage_t z, const __amd_fp4x2_storage_t w) {
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t), "");
   union {
     __amd_fp4x2_storage_t fp4x2[4];
     __amd_fp4x8_storage_t fp4x8;
@@ -169,7 +169,7 @@ __amd_create_fp4x8(const __amd_fp4x2_storage_t x, const __amd_fp4x2_storage_t y,
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t
 __amd_create_fp8x8(const __amd_fp8x2_storage_t x, const __amd_fp8x2_storage_t y,
                    const __amd_fp8x2_storage_t z, const __amd_fp8x2_storage_t w) {
-  static_assert(sizeof(__amd_fp8x2_storage_t[4]) == sizeof(__amd_fp8x8_storage_t));
+  static_assert(sizeof(__amd_fp8x2_storage_t[4]) == sizeof(__amd_fp8x8_storage_t), "");
   union {
     __amd_fp8x2_storage_t fp8x2[4];
     __amd_fp8x8_storage_t fp8x8;
@@ -186,7 +186,7 @@ __amd_create_fp8x8(const __amd_fp8x2_storage_t x, const __amd_fp8x2_storage_t y,
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_extract_fp8(const __amd_fp8x2_storage_t x,
                                                                     const size_t index) {
-  static_assert(sizeof(__amd_fp8_storage_t[2]) == sizeof(__amd_fp8x2_storage_t));
+  static_assert(sizeof(__amd_fp8_storage_t[2]) == sizeof(__amd_fp8x2_storage_t), "");
   union {
     __amd_fp8x2_storage_t fp8x2;
     __amd_fp8_storage_t fp8[2];
@@ -204,7 +204,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_extract_fp8(const __amd_
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t
 __amd_extract_fp8x2(const __amd_fp8x8_storage_t x, const size_t index) {
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_fp8x8_storage_t fp8x8;
     __amd_fp8x2_storage_t fp8x2[4];
@@ -295,8 +295,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float(
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_float_to_fp8_sr(
     const float val, const __amd_fp8_interpretation_t interpret, const unsigned int seed) {
-  static_assert(sizeof(float) == sizeof(__amd_fp8_storage_t[4]));
-  static_assert(sizeof(unsigned int) == sizeof(uint32_t));
+  static_assert(sizeof(float) == sizeof(__amd_fp8_storage_t[4]), "");
+  static_assert(sizeof(unsigned int) == sizeof(uint32_t), "");
   union {
     unsigned int ui32;
     uint32_t ui32t;
@@ -357,7 +357,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t
 __amd_cvt_float_to_fp8_sr_scale(const float val, const __amd_fp8_interpretation_t interpret,
                                 const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   union u {
     unsigned int ui32;
     __amd_fp8_storage_t fp8[4];
@@ -371,7 +371,7 @@ __amd_cvt_float_to_fp8_sr_scale(const float val, const __amd_fp8_interpretation_
   }
   return u.fp8[0];
 #else
-  static_assert(sizeof(uint32_t) == sizeof(unsigned int));
+  static_assert(sizeof(uint32_t) == sizeof(unsigned int), "");
   union u {
     uint32_t ui32t;
     __amd_fp8_storage_t fp8[4];
@@ -427,7 +427,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx2_storage_t __amd_cvt_fp8x2_to_floatx2
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_floatx2_to_fp8x2(
     const __amd_floatx2_storage_t val, const __amd_fp8_interpretation_t interpret) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(int));
+  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(int), "");
   union {
     int i32;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -464,7 +464,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_floatx2_to_fp4x2_s
     const __amd_floatx2_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -473,7 +473,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_floatx2_to_fp4x2_s
                                                        __amd_scale_to_float(scale), 1);
   return u.fp4x2[1];
 #else
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
   union u {
     uint32_t ui32t;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -518,7 +518,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t
 __amd_cvt_floatx2_to_fp4x2_scale(const __amd_floatx2_storage_t val,
                                  const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -576,7 +576,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_floatx2_to_fp8x2_s
     const __amd_floatx2_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -672,7 +672,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t __amd_cvt_fp8x2_to_fp16x2_s
     const __amd_fp8x2_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_fp8x2_storage_t fp8x2[2];
     unsigned int ui32;
@@ -707,8 +707,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x8_storage_t __amd_cvt_fp8x8_to_fp16x8_s
     const __amd_fp8x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp16x8_storage_t) == sizeof(__amd_fp16x2_storage_t[4]));
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_fp16x8_storage_t) == sizeof(__amd_fp16x2_storage_t[4]), "");
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_fp16x8_storage_t fp16x8;
     __amd_fp16x2_storage_t fp16x2[4];
@@ -780,7 +780,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x2_storage_t __amd_cvt_fp8x2_to_bf16x2_s
     const __amd_fp8x2_storage_t in, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_fp8x2_storage_t fp8x2[2];
     unsigned int ui32;
@@ -815,8 +815,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x8_storage_t __amd_cvt_fp8x8_to_bf16x8_s
     const __amd_fp8x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_bf16x8_storage_t) == sizeof(__amd_bf16x2_storage_t[4]));
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_bf16x8_storage_t) == sizeof(__amd_bf16x2_storage_t[4]), "");
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_bf16x8_storage_t bf16x8;
     __amd_bf16x2_storage_t bf16x2[4];
@@ -978,8 +978,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t __amd_cvt_fp4x2_to_fp16x2_s
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x8_storage_t __amd_cvt_fp4x8_to_fp16x8_scale(
     const __amd_fp4x8_storage_t in, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
-  static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
+  static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t), "");
   union {
     __amd_fp4x8_storage_t fp4x8;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1041,8 +1041,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x2_storage_t __amd_cvt_fp4x2_to_bf16x2_s
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x8_storage_t __amd_cvt_fp4x8_to_bf16x8_scale(
     const __amd_fp4x8_storage_t in, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
-  static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
+  static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t), "");
   union {
     __amd_fp4x8_storage_t fp4x8;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1086,7 +1086,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x8_storage_t __amd_cvt_fp4x8_to_bf16x8_s
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx8_storage_t __amd_cvt_fp4x8_to_floatx8_scale(
     const __amd_fp4x8_storage_t val, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t), "");
   union {
     __amd_fp4x8_storage_t fp4x8;
     __amd_fp4x2_storage_t fp8x2[4];
@@ -1132,8 +1132,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx8_storage_t __amd_cvt_fp4x8_to_floatx8
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_floatx8_to_fp4x8_scale(
     const __amd_floatx8_storage_t in, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]));
-  static_assert(sizeof(__amd_fp4x8_storage_t) == sizeof(__amd_fp4x2_storage_t[4]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]), "");
+  static_assert(sizeof(__amd_fp4x8_storage_t) == sizeof(__amd_fp4x2_storage_t[4]), "");
   union hold_u {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1194,8 +1194,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
     const __amd_fp16x2_storage_t in, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
+  static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1205,7 +1205,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
       : __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(u.shortx2, in, __amd_scale_to_float(scale), false);
   return u.fp8x2[0];
 #else
-  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(uint32_t), "");
   using namespace fcbx;
   union {
     uint32_t ui32;
@@ -1236,7 +1236,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_bf16x2_to_fp8x2_sc
     const __amd_bf16x2_storage_t in, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1277,8 +1277,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_bf16x8_to_fp8x8_sc
     const __amd_bf16x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8x2_storage_t[4]) == sizeof(__amd_fp8x8_storage_t));
-  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8x2_storage_t[4]) == sizeof(__amd_fp8x8_storage_t), "");
+  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(unsigned int), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1355,7 +1355,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx8_storage_t __amd_cvt_fp8x8_to_floatx8
     const __amd_fp8x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_fp8x8_storage_t fp8x8;
     __amd_fp8x2_storage_t fp8x2[4];
@@ -1455,8 +1455,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16_storage_t
 __amd_cvt_fp8_to_bf16_scale(const __amd_fp8_storage_t val,
                             const __amd_fp8_interpretation_t interpret, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]), "");
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_fp8_storage_t fp8[4];
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1679,7 +1679,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp6x32_storage_t __amd_cvt_bf16x32_to_fp6x32
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_bf16x2_to_fp4x2_scale(
     const __amd_bf16x2_storage_t val, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1706,8 +1706,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_bf16x2_to_fp4x2_sc
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_bf16x8_to_fp4x8_scale(
     const __amd_bf16x8_storage_t val, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t), "");
   union hold_u {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1774,7 +1774,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_bf16x8_to_fp4x8_sc
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_fp16x2_to_fp4x2_scale(
     const __amd_fp16x2_storage_t val, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1801,8 +1801,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_fp16x2_to_fp4x2_sc
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_fp16x8_to_fp4x8_scale(
     const __amd_fp16x8_storage_t val, const __amd_fp4_interpretation_t, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__amd_fp4x8_storage_t), "");
   union hold_u {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1871,7 +1871,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_floatx8_to_fp4x8_s
     const __amd_floatx8_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1943,7 +1943,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_bf16x2_to_fp4x2_sr
     const __amd_bf16x2_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -1973,7 +1973,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_bf16x8_to_fp4x8_sr
     const __amd_bf16x8_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -2045,7 +2045,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_fp16x2_to_fp4x2_sr
     const __amd_fp16x2_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -2075,7 +2075,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x8_storage_t __amd_cvt_fp16x8_to_fp4x8_sr
     const __amd_fp16x8_storage_t val, const __amd_fp4_interpretation_t, const unsigned int seed,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int), "");
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -2148,7 +2148,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_floatx8_to_fp8x8_s
     const __amd_floatx8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   __amd_fp8x8_storage_t ret;
   union hold_u {
     unsigned int ui32;
@@ -2245,7 +2245,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_fp16_to_fp8_sr_scale
     const __amd_fp16_storage_t val, const __amd_fp8_interpretation_t interpret,
     const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   union u {
     unsigned int ui32;
     __amd_fp8_storage_t fp8[4];
@@ -2281,7 +2281,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_fp16x8_to_fp8x8_sr
     const __amd_fp16x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   __amd_fp8x8_storage_t ret;
   union hold_u {
     unsigned int ui32;
@@ -2378,7 +2378,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_bf16_to_fp8_sr_scale
     const __amd_bf16_storage_t val, const __amd_fp8_interpretation_t interpret,
     const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   union u {
     unsigned int ui32;
     __amd_fp8_storage_t fp8[4];
@@ -2414,7 +2414,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_bf16x8_to_fp8x8_sr
     const __amd_bf16x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const unsigned int seed, const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   __amd_fp8x8_storage_t ret;
   union hold_u {
     unsigned int ui32;
@@ -2535,7 +2535,7 @@ __amd_cvt_fp8_to_fp16(const __amd_fp8_storage_t val, const __amd_fp8_interpretat
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t __amd_cvt_fp8x2_to_fp16x2(
     const __amd_fp8x2_storage_t val, const __amd_fp8_interpretation_t interpret) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_fp8x2_storage_t fp8x2[2];
     unsigned int ui32;
@@ -2568,7 +2568,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t __amd_cvt_fp8x2_to_fp16x2(
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2(
     const __amd_fp16x2_storage_t val, const __amd_fp8_interpretation_t interpret) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -2605,8 +2605,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_fp16x8_to_fp8x8_sc
     const __amd_fp16x8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -2694,8 +2694,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_floatx8_to_fp8x8_s
     const __amd_floatx8_storage_t val, const __amd_fp8_interpretation_t interpret,
     const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]));
+  static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
+  static_assert(sizeof(__amd_fp8x8_storage_t) == sizeof(__amd_fp8x2_storage_t[4]), "");
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -2769,7 +2769,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x8_storage_t __amd_cvt_floatx8_to_fp8x8_s
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_fp16_to_fp8_sr(
     const __amd_fp16_storage_t val, const __amd_fp8_interpretation_t interpret, const short sr) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+  static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
   union u {
     unsigned int ui32;
     __amd_fp8_storage_t fp8[4];
@@ -2853,7 +2853,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp16x2_storage_t __amd_cvt_half2_to_fp16x2(c
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __hip_bfloat16
 __amd_cvt_bf16_to_hipbf16(const __amd_bf16_storage_t val) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t), "");
   union {
     __amd_bf16_storage_t bf16;
     __hip_bfloat16 hip_bf16;
@@ -2869,7 +2869,7 @@ __amd_cvt_bf16_to_hipbf16(const __amd_bf16_storage_t val) {
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __hip_bfloat162
 __amd_cvt_bf16x2_to_hipbf162(const __amd_bf16x2_storage_t val) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t), "");
   union {
     __amd_bf16x2_storage_t bf16;
     __hip_bfloat162 hip_bf16;
@@ -2885,7 +2885,7 @@ __amd_cvt_bf16x2_to_hipbf162(const __amd_bf16x2_storage_t val) {
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16_storage_t
 __amd_cvt_hipbf16_to_bf16(const __hip_bfloat16 val) {
-  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t));
+  static_assert(sizeof(__hip_bfloat16) == sizeof(__amd_bf16_storage_t), "");
   union {
     __hip_bfloat16 hip_bf16;
     __amd_bf16_storage_t bf16;
@@ -2901,7 +2901,7 @@ __amd_cvt_hipbf16_to_bf16(const __hip_bfloat16 val) {
  */
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_bf16x2_storage_t
 __amd_cvt_hipbf162_to_bf16x2(const __hip_bfloat162 val) {
-  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t));
+  static_assert(sizeof(__hip_bfloat162) == sizeof(__amd_bf16x2_storage_t), "");
   union {
     __hip_bfloat162 hip_bf16;
     __amd_bf16x2_storage_t bf16;

--- a/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
+++ b/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
@@ -26,11 +26,11 @@ THE SOFTWARE.
 
 #include "amd_hip_ocp_host.hpp"
 
-static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]));
-static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
-static_assert(sizeof(int) == sizeof(__amd_fp8x2_storage_t[2]));
-static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
-static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
+static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]), "");
+static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]), "");
+static_assert(sizeof(int) == sizeof(__amd_fp8x2_storage_t[2]), "");
+static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
+static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]), "");
 
 struct __hipext_ocp_fp8_e4m3 {
   __amd_fp8_storage_t __x;
@@ -123,7 +123,7 @@ struct __hipext_ocp_fp8_e4m3 {
                                                         const unsigned int seed,
                                                         const __amd_scale_t scale) {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int));
+    static_assert(sizeof(__amd_fp8_storage_t[4]) == sizeof(unsigned int), "");
     union u {
       unsigned int ui32;
       __amd_fp8_storage_t fp8[4];
@@ -155,7 +155,7 @@ struct __hipext_ocp_fp8_e4m3 {
 
   __OCP_FP_HOST_DEVICE__ __amd_bf16_storage_t get_scaled_bf16(const __amd_scale_t scale) const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]));
+    static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]), "");
     union {
       __amd_fp8_storage_t fp8[4];
       unsigned int ui32;
@@ -311,7 +311,7 @@ struct __hipext_ocp_fp8_e5m2 {
 
   __OCP_FP_HOST_DEVICE__ __amd_bf16_storage_t get_scaled_bf16(const __amd_scale_t scale) const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]));
+    static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]), "");
     union {
       __amd_fp8_storage_t fp8[4];
       unsigned int ui32;
@@ -904,7 +904,7 @@ struct __hipext_ocp_fp4x2_e2m1 {
   __amd_fp4x2_storage_t __x;
   static const __amd_fp4_interpretation_t __default_interpret = __AMD_OCP_E2M1;
 
-  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]));
+  static_assert(sizeof(unsigned int) == sizeof(__amd_fp4x2_storage_t[4]), "");
 
   __OCP_FP_HOST_DEVICE__ __hipext_ocp_fp4x2_e2m1(const float a, const float b,
                                                  const __amd_scale_t scale) {
@@ -973,7 +973,7 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
     union u {
       uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
@@ -1000,7 +1000,7 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                           __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
     union u {
       uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
@@ -1027,7 +1027,7 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
     union u {
       uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];

--- a/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -75,7 +75,7 @@ static const float ieee754_nan = std::numeric_limits<float>::quiet_NaN();
 static const float ieee754_inf = std::numeric_limits<float>::infinity();
 
 __OCP_FP_HOST_DEVICE_STATIC__ uint32_t U32(float f) {
-  static_assert(sizeof(uint32_t) == sizeof(float));
+  static_assert(sizeof(uint32_t) == sizeof(float), "");
   union {
     float f32;
     uint32_t ui32;
@@ -84,7 +84,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t U32(float f) {
 }
 
 __OCP_FP_HOST_DEVICE_STATIC__ float F32(uint32_t u32) {
-  static_assert(sizeof(uint32_t) == sizeof(float));
+  static_assert(sizeof(uint32_t) == sizeof(float), "");
   union {
     uint32_t ui32;
     float f32;
@@ -464,7 +464,7 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makezero(Encoding E, uint3
 template <typename T, Encoding E, bool sat>
 __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
-  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7);
+  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
 
   const auto& enc = encodings[(size_t)E];
   const auto dstE = []() -> Encoding {
@@ -560,9 +560,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
 template <typename T, Encoding E, bool sat>
 __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
-  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7);
-  static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float));
-  static_assert(sizeof(__amd_bf16_storage_t[2]) == sizeof(float));
+  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
+  static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float), "");
+  static_assert(sizeof(__amd_bf16_storage_t[2]) == sizeof(float), "");
   union {
     float f32;
     __amd_fp16_storage_t fp16[2];
@@ -674,9 +674,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
 template <typename T, Encoding E, bool sat>
 __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
-  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7);
-  static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float));
-  static_assert(sizeof(__amd_bf16_storage_t[2]) == sizeof(float));
+  static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
+  static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float), "");
+  static_assert(sizeof(__amd_bf16_storage_t[2]) == sizeof(float), "");
   union {
     float f32;
     __amd_fp16_storage_t fp16[2];
@@ -836,7 +836,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, int8_t scale 
     unsigned long long padded;
   } __attribute__((packed));
 
-  static_assert(sizeof(other_type) == sizeof(fp6x32_packed));
+  static_assert(sizeof(other_type) == sizeof(fp6x32_packed), "");
   union {
     other_type o;
     fp6x32_packed fp6;

--- a/hipamd/include/hip/amd_detail/amd_hip_ocp_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_ocp_types.h
@@ -30,14 +30,14 @@ THE SOFTWARE.
 #define __OCP_FP_DEVICE_STATIC__ __OCP_FP_DEVICE__ static __inline__ __attribute__((always_inline))
 #define __OCP_FP_HOST_DEVICE_STATIC__ __OCP_FP_HOST_DEVICE__ static
 
-static_assert(sizeof(unsigned int) == 4);
-static_assert(sizeof(float) == 4);
-static_assert(sizeof(unsigned short) == 2);
+static_assert(sizeof(unsigned int) == 4, "");
+static_assert(sizeof(float) == 4, "");
+static_assert(sizeof(unsigned short) == 2, "");
 
 #if (defined(__clang__) && (__clang_major__ > 17) && defined(__HIP__)) ||                          \
     (defined(__GNUC__) && (__GNUC__ > 13))
-static_assert(sizeof(__bf16) == 2);
-static_assert(sizeof(_Float16) == 2);
+static_assert(sizeof(__bf16) == 2, "");
+static_assert(sizeof(_Float16) == 2, "");
 #endif
 
 // Although we do have some abstractions of half and bfloat16, since this will be a standalone
@@ -87,4 +87,4 @@ typedef short __attribute__((vector_size(4))) __amd_shortx2_storage_t;
 #error "Only supported by HIPCC or GCC >= 13."
 #endif
 
-static_assert(sizeof(__amd_uintx2_storage_t) == sizeof(__amd_fp8x8_storage_t));
+static_assert(sizeof(__amd_uintx2_storage_t) == sizeof(__amd_fp8x8_storage_t), "");

--- a/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/hipamd/include/hip/amd_detail/amd_hip_vector_types.h
@@ -63,18 +63,24 @@ inline constexpr unsigned int next_pot(unsigned int x) {
 template <typename T, unsigned int n>
 __attribute__((always_inline)) __HOST_DEVICE__ typename HIP_vector_base<T, n>::Native_vec_*
 get_native_pointer(HIP_vector_base<T, n>& base_vec) {
-  static_assert(sizeof(base_vec) == sizeof(typename HIP_vector_base<T, n>::Native_vec_));
-  static_assert(__hip_internal::alignment_of<HIP_vector_base<T, n>>::value ==
-                __hip_internal::alignment_of<typename HIP_vector_base<T, n>::Native_vec_>::value);
+  static_assert(sizeof(base_vec) == sizeof(typename HIP_vector_base<T, n>::Native_vec_),
+                "Cannot safely reinterpret between types of different sizes");
+  static_assert(
+      __hip_internal::alignment_of<HIP_vector_base<T, n>>::value ==
+          __hip_internal::alignment_of<typename HIP_vector_base<T, n>::Native_vec_>::value,
+      "Cannot safely reinterpret to type of different alignment");
   return reinterpret_cast<typename HIP_vector_base<T, n>::Native_vec_*>(&base_vec.x);
 };
 
 template <typename T, unsigned int n>
 __attribute__((always_inline)) __HOST_DEVICE__ const typename HIP_vector_base<T, n>::Native_vec_*
 get_native_pointer(const HIP_vector_base<T, n>& base_vec) {
-  static_assert(sizeof(base_vec) == sizeof(typename HIP_vector_base<T, n>::Native_vec_));
-  static_assert(__hip_internal::alignment_of<HIP_vector_base<T, n>>::value ==
-                __hip_internal::alignment_of<typename HIP_vector_base<T, n>::Native_vec_>::value);
+  static_assert(sizeof(base_vec) == sizeof(typename HIP_vector_base<T, n>::Native_vec_),
+                "Cannot safely reinterpret between types of different sizes");
+  static_assert(
+      __hip_internal::alignment_of<HIP_vector_base<T, n>>::value ==
+          __hip_internal::alignment_of<typename HIP_vector_base<T, n>::Native_vec_>::value,
+      "Cannot safely reinterpret to type of different alignment");
   return reinterpret_cast<const typename HIP_vector_base<T, n>::Native_vec_*>(&base_vec.x);
 };
 }  // Namespace hip_impl.


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Closes SWDEV-536621

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

All static_asserts within the include directory are given a message to prevent warnings

## Why are these changes needed?

static_asserts with no message is a c++17 feature. This is fine when we are compiling our dynamic library as we use the c++17 standard. However a user could be trying to use c++14 when including our headers. This prevents a warning being emited for them

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
