### PR TITLE
SWDEV-532052 - Auto Generated CodeQL Fix for alert 347

### DIFF
--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -3278,7 +3278,7 @@ hipError_t hipIpcOpenMemHandle(void** dev_ptr, hipIpcMemHandle_t handle, unsigne
       LogPrintfError(
           "Cannot attach ipc_handle: with ipc_size: %u"
           "ipc_offset: %u flags: %u",
-          ihandle->psize, flags);
+          ihandle->psize, ihandle->poffset, flags);
       HIP_RETURN(hipErrorInvalidDevicePointer);
     }
     amd_mem_obj = getMemoryObject(*dev_ptr, offset);


### PR DESCRIPTION
Alert#347 - Too few arguments to formatting function

Alert url: https://github.com/AMD-ROCm-Internal/clr/security/code-scanning/347

Alert severity: medium

Explanation:
The format string has three placeholders (%u, %u, %u) but previously only two arguments (ihandle->psize and flags) were passed. Adding ihandle->poffset as the missing argument ensures that the format string and its arguments match correctly.