### PR TITLE
SWDEV-532052 - Auto Generated CodeQL Fix for alert 331

### DIFF
--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -3281,7 +3281,7 @@ hipError_t hipIpcOpenMemHandle(void** dev_ptr, hipIpcMemHandle_t handle, unsigne
       LogPrintfError(
           "Cannot attach ipc_handle: with ipc_size: %u"
           "ipc_offset: %u flags: %u",
-          ihandle->psize, flags);
+          ihandle->psize, ihandle->poffset, flags);
       HIP_RETURN(hipErrorInvalidDevicePointer);
     }
     amd_mem_obj = getMemoryObject(*dev_ptr, offset);


### PR DESCRIPTION
Alert#331 - Too few arguments to formatting function

Alert url: https://github.com/AMD-ROCm-Internal/clr/security/code-scanning/331

Alert severity: medium

Explanation:
The format string on line 3282–3283 has three placeholders (%u, %u, %u) but was only supplied with two arguments (ihandle->psize and flags). Adding ihandle->poffset as the second argument ensures that all placeholders are matched properly.