### PR TITLE
SWDEV-532052 - Auto Generated CodeQL Fix for alert 332

### DIFF
--- a/hipamd/src/hip_device.cpp
+++ b/hipamd/src/hip_device.cpp
@@ -477,7 +477,7 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
   memcpy(deviceProps.uuid.bytes, info.uuid_, sizeof(info.uuid_));
   deviceProps.totalGlobalMem = info.globalMemSize_;
   deviceProps.sharedMemPerBlock = info.localMemSizePerCU_;
-  deviceProps.sharedMemPerMultiprocessor = info.localMemSizePerCU_ * info.numRTCUs_;
+  deviceProps.sharedMemPerMultiprocessor = static_cast<size_t>(info.localMemSizePerCU_) * info.numRTCUs_;
   deviceProps.regsPerBlock = info.availableRegistersPerCU_;
   deviceProps.warpSize = info.wavefrontWidth_;
   deviceProps.maxThreadsPerBlock = info.maxWorkGroupSize_;


### PR DESCRIPTION
Alert#332 - Multiplication result converted to larger type

Alert url: https://github.com/AMD-ROCm-Internal/clr/security/code-scanning/332

Alert severity: high

Explanation:
Casting one operand to size_t ensures that the multiplication is performed in a larger type, preventing an overflow that could happen if both operands are 32‐bit and their product exceeds the maximum representable range before being converted.