### PR TITLE
SWDEV-407262 Return appropriate error during lazy load

### DIFF
--- a/hipamd/src/hip_code_object.cpp
+++ b/hipamd/src/hip_code_object.cpp
@@ -1435,6 +1435,9 @@ hipError_t StatCO::getStatFuncAttr(hipFuncAttributes* func_attr, const void* hos
   if (*(module) == nullptr) {
     hipError_t err = digestFatBinary(module_to_hostModule_[module], *module);
     assert(err == hipSuccess);
+    if (err == hipErrorNoBinaryForGpu) {
+      return err;
+    }
   }
 
   return it->second->getStatFuncAttr(func_attr, deviceId);


### PR DESCRIPTION
In case that code object unable to find code object for all current devices, the error hipErrorNoBinaryForGpu has to be returned.