### PR TITLE
Reject VMM allocations in hipIpcGetMemHandle

### DIFF
--- a/rocclr/device/device.cpp
+++ b/rocclr/device/device.cpp
@@ -1051,6 +1051,13 @@ bool Device::IpcCreate(void* dev_ptr, size_t* mem_size, char* handle, size_t* me
     return false;
   }
 
+  // VMM allocations must use hipMemExportToShareableHandle for IPC.
+  if (amd_mem_obj->getMemFlags() & CL_MEM_VA_RANGE_AMD) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM, 
+             "IPC is not supported for VMM allocations (dev_ptr: 0x%x)", dev_ptr);
+    return false;
+  }
+
   // Get the original pointer from the amd::Memory object
   void* orig_dev_ptr = nullptr;
   if (amd_mem_obj->getSvmPtr() != nullptr) {


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
[<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->](https://github.com/ROCm/clr/issues/265)

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Add VMM type check for hipIpcGetMemHandle

## Why are these changes needed?

hipIpcGetMemHandle currently does not validate whether the input pointer was allocated via the VMM path (hipMemAddressReserve + hipMemMap). When a VMM-allocated pointer is passed:
1. MemObjMap::FindMemObj finds the VMM sub-buffer (added by hipMemMap) since it shares MemObjMap_ with hipMalloc allocations
2. Buffer::ExportHandle calls hsa_amd_ipc_memory_create on the VMM pointer, which expects hsa_amd_memory_pool_allocate-backed memory
3. This produces an invalid hipIpcMemHandle_t
4. The receiving process's hipIpcOpenMemHandle → hsa_amd_ipc_memory_attach fails with hipErrorInvalidDevicePointer
5. On process cleanup, the inconsistent BO pin state triggers amdttm_bo_unpin WARNING followed by kernel BUG (slab corruption), leaving GPU VRAM permanently leaked until hard reboot

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
