### PR TITLE
Update README to note deprecation and point towards rocm-systems/clr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # AMD CLR - Compute Language Runtimes
 
+> [!CAUTION]
+> The clr repository is retired, please use the [ROCm/rocm-systems](https://github.com/ROCm/rocm-systems/tree/develop/projects/clr) repository for development. This `develop` branch will only accept patch updates from a bot that mirrors clr-specific updates from `rocm-systems` into here.
+
 AMD CLR (Compute Language Runtime) contains source codes for AMD's compute languages runtimes: `HIP` and `OpenCL™`.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Point users from this repo to rocm-system/clr
<!-- Please give a short summary of the change. -->

## Why are these changes needed?

Looks like https://github.com/ROCm/clr/commit/6f73271be75f092f88fd644a7908ee53eb981182 removed the deprecation note by mistake.
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [x] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
