### PR TITLE
Avoid per-row SDMA fallback for narrow/tall hipMemcpy2D rects

### DIFF
--- a/rocclr/device/rocm/rocblit.cpp
+++ b/rocclr/device/rocm/rocblit.cpp
@@ -1916,8 +1916,25 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
   bool result = false;
   bool rejected = false;
 
+  // hsa_amd_memory_async_copy_rect requires dword-aligned row/slice pitches.
+  // When they are not aligned, DmaBlitManager::copyBufferRect falls back to one
+  // hsa_amd_memory_async_copy per row. For tall, narrow host<->device rects
+  // (e.g. hipMemcpy2D with width=1 and a very large height) this issues one
+  // single-byte SDMA submission per row - up to millions of descriptors - which
+  // is orders of magnitude slower than the shader rect kernel below
+  // (BlitCopyBufferRect handles 1-byte alignment in a single dispatch). Skip the
+  // SDMA rect path in that pathological case and let the shader kernel handle it.
+  constexpr size_t kSdmaRectRowSerializeLimit = 256;
+  const bool dwordAlignedRect =
+      ((srcRectIn.rowPitch_ % 4) == 0) && ((srcRectIn.slicePitch_ % 4) == 0) &&
+      ((dstRectIn.rowPitch_ % 4) == 0) && ((dstRectIn.slicePitch_ % 4) == 0);
+  const bool hostDeviceRect =
+      srcMemory.isHostMemDirectAccess() != dstMemory.isHostMemDirectAccess();
+  const bool sdmaRectWouldSerialize = !dwordAlignedRect && hostDeviceRect &&
+      ((sizeIn[1] * sizeIn[2]) > kSdmaRectRowSerializeLimit);
+
   // Fall into the ROC path for rejected transfers
-  if (dev().info().pcie_atomics_ &&
+  if (dev().info().pcie_atomics_ && !sdmaRectWouldSerialize &&
       (setup_.disableCopyBufferRect_ || srcMemory.isHostMemDirectAccess() ||
        dstMemory.isHostMemDirectAccess())) {
     result = DmaBlitManager::copyBufferRect(srcMemory, dstMemory, srcRectIn, dstRectIn, sizeIn,


### PR DESCRIPTION
KernelBlitManager::copyBufferRect routes host<->device rect copies to the SDMA rect path (DmaBlitManager::copyBufferRect) first. The hardware rect copy hsa_amd_memory_async_copy_rect requires dword-aligned row/slice pitches; when they are not aligned, DmaBlitManager::copyBufferRect degenerates into one hsa_amd_memory_async_copy per row.

For tall, narrow rects such as hipMemcpy2D(width=1, height=1M) this submits ~1,048,576 single-byte SDMA copies. Measured on gfx942 / ROCm 7.2, a 1 MB width=1 H2D copy took ~8.6 s (up to ~17 s in a separate sweep), versus ~4 ms for width=4 and ~0.03 ms for a flat hipMemcpy of the same bytes. Pinning the host buffer does not help, because the cost is per-row submission overhead, not page-locking (pinned vs pageable differ by ~0.1%, and warmup does not change it). rocprofv3 confirms one MEMORY_COPY record per row for width=1 versus a single record for width=4.

Detect this case (row/slice pitch not dword-aligned, host<->device direction, row count > 256) and skip the SDMA rect path so the existing shader BlitCopyBufferRect kernel (alignment list {16,4,1}) handles the copy in a single dispatch instead of issuing one SDMA descriptor per row.

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
